### PR TITLE
Bring versioning back in

### DIFF
--- a/MANIFEST.IN
+++ b/MANIFEST.IN
@@ -9,7 +9,6 @@ include .gitignore
 include LICENSE
 include tox.ini
 include *.yaml
-include piksi_tools/RELEASE-VERSION
 recursive-include piksi_tools/ *.py
 recursive-include piksi_tools/console/images *
 prune docs/_build

--- a/MANIFEST.IN
+++ b/MANIFEST.IN
@@ -9,6 +9,7 @@ include .gitignore
 include LICENSE
 include tox.ini
 include *.yaml
+include piksi_tools/RELEASE-VERSION
 recursive-include piksi_tools/ *.py
 recursive-include piksi_tools/console/images *
 prune docs/_build

--- a/piksi_tools/version.py
+++ b/piksi_tools/version.py
@@ -75,7 +75,7 @@ def get_git_version():
     version = call_git_describe()
 
     # Take off the leading if present.
-    if version[0] == 'v':
+    if version is not None and version[0] == 'v':
       version = version[1:]
 
     #adapt to PEP 386 compatible versioning scheme

--- a/piksi_tools/version.py
+++ b/piksi_tools/version.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Author: Douglas Creager <dcreager@dcreager.net>
+# This file is placed into the public domain.
+# Adapted from Gist: https://gist.github.com/3067886
+
+# Calculates the current version number.  If possible, this is the
+# output of “git describe”, modified to conform to the versioning
+# scheme that setuptools uses.  If “git describe” returns an error
+# (most likely because we're in an unpacked copy of a release tarball,
+# rather than in a git working copy), then we fall back on reading the
+# contents of the RELEASE-VERSION file.
+#
+# To use this script, simply import it your setup.py file, and use the
+# results of get_git_version() as your package version:
+#
+# from version import *
+#
+# setup(
+#     version=get_git_version(),
+#     .
+#     .
+#     .
+# )
+#
+# This will automatically update the RELEASE-VERSION file, if
+# necessary.  Note that the RELEASE-VERSION file should *not* be
+# checked into git; please add it to your top-level .gitignore file.
+#
+# You'll probably want to distribute the RELEASE-VERSION file in your
+# sdist tarballs; to do this, just create a MANIFEST.in file that
+# contains the following line:
+#
+#   include RELEASE-VERSION
+
+__all__ = ("get_git_version")
+
+from subprocess import Popen, PIPE
+import os
+
+def call_git_describe():
+    try:
+        p = Popen(['git', 'describe', '--tags', '--dirty', '--always'],
+                  stdout=PIPE, stderr=PIPE)
+        p.stderr.close()
+        line = p.stdout.readlines()[0]
+        return line.strip()
+    except:
+        return None
+
+
+def read_release_version():
+    try:
+        f = open(os.path.join(os.path.dirname(__file__), 'RELEASE-VERSION'), "r")
+        try:
+            version = f.readlines()[0]
+            return version.strip()
+        finally:
+            f.close()
+    except:
+        return None
+
+
+def write_release_version(version):
+    f = open(os.path.join(os.path.dirname(__file__), 'RELEASE-VERSION'), "w")
+    f.write("%s\n" % version)
+    f.close()
+
+
+def get_git_version():
+    # Read in the version that's currently in RELEASE-VERSION.
+    release_version = read_release_version()
+
+    # First try to get the current version using “git describe”.
+    version = call_git_describe()
+
+    # Take off the leading if present.
+    if version[0] == 'v':
+      version = version[1:]
+
+    #adapt to PEP 386 compatible versioning scheme
+    version = pep386adapt(version)
+
+    # If that doesn't work, fall back on the value that's in
+    # RELEASE-VERSION.
+    if version is None:
+        version = release_version
+
+    # If we still don't have anything, that's an error.
+    if version is None:
+        raise ValueError("Cannot find the version number!")
+
+    # If the current version is different from what's in the
+    # RELEASE-VERSION file, update the file to be current.
+    if version != release_version:
+        write_release_version(version)
+
+    # Finally, return the current version.
+    return version
+
+
+def pep386adapt(version):
+    if version is not None and '-' in version:
+        # adapt git-describe version to be in line with PEP 386
+        # Break PEP 386 a bit here and append the Git hash
+        parts = version.split('-')
+        if len(parts) > 2:
+          version = '%s.post%s-%s' % (
+              parts[0], parts[1],
+              '-'.join(parts[2:])
+          )
+        return version
+    else:
+        return version
+
+VERSION = get_git_version()
+
+if __name__ == "__main__":
+    print get_git_version()
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pytest-cov==1.8.1
 tox==1.8.1
 virtualenv==1.11.6
 intelhex
+

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 from setuptools import setup
 from subprocess import Popen, PIPE
 import os
+import piksi_tools.version
 
 def call_git_describe():
     try:
@@ -75,7 +76,7 @@ def get_git_version():
     # Finally, return the current version.
     return version
 
-VERSION = get_git_version()
+VERSION = piksi_tools.version.VERSION
 
 CLASSIFIERS = [
   'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,81 @@
 #!/usr/bin/env python
 
 from setuptools import setup
+from subprocess import Popen, PIPE
 import os
 
-VERSION = "0.16"
+def call_git_describe():
+    try:
+        p = Popen(['git', 'describe', '--tags', '--dirty', '--always'],
+                  stdout=PIPE, stderr=PIPE)
+        p.stderr.close()
+        line = p.stdout.readlines()[0]
+        return line.strip()
+    except:
+        return None
+
+def read_release_version():
+    try:
+        f = open(os.path.join(os.path.dirname(__file__), 'RELEASE-VERSION'), "r")
+        try:
+            version = f.readlines()[0]
+            return version.strip()
+        finally:
+            f.close()
+    except:
+        return None
+
+def write_release_version(version):
+    f = open(os.path.join(os.path.dirname(__file__), 'RELEASE-VERSION'), "w")
+    f.write("%s\n" % version)
+    f.close()
+
+def pep386adapt(version):
+    if version is not None and '-' in version:
+        # adapt git-describe version to be in line with PEP 386
+        # Break PEP 386 a bit here and append the Git hash
+        parts = version.split('-')
+        if len(parts) > 2:
+          version = '%s.post%s-%s' % (
+              parts[0], parts[1],
+              '-'.join(parts[2:])
+          )
+        return version
+    else:
+        return version
+
+def get_git_version():
+    # Read in the version that's currently in RELEASE-VERSION.
+    release_version = read_release_version()
+
+    # First try to get the current version using 'git describe'.
+    version = call_git_describe()
+
+    # Take off the leading if present.
+    if version[0] == 'v':
+      version = version[1:]
+
+    #adapt to PEP 386 compatible versioning scheme
+    version = pep386adapt(version)
+
+    # If that doesn't work, fall back on the value that's in
+    # RELEASE-VERSION.
+    if version is None:
+        version = release_version
+
+    # If we still don't have anything, that's an error.
+    if version is None:
+        raise ValueError("Cannot find the version number!")
+
+    # If the current version is different from what's in the
+    # RELEASE-VERSION file, update the file to be current.
+    if version != release_version:
+        write_release_version(version)
+
+    # Finally, return the current version.
+    return version
+
+VERSION = get_git_version()
 
 CLASSIFIERS = [
   'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -1,82 +1,8 @@
 #!/usr/bin/env python
 
 from setuptools import setup
-from subprocess import Popen, PIPE
 import os
-import piksi_tools.version
-
-def call_git_describe():
-    try:
-        p = Popen(['git', 'describe', '--tags', '--dirty', '--always'],
-                  stdout=PIPE, stderr=PIPE)
-        p.stderr.close()
-        line = p.stdout.readlines()[0]
-        return line.strip()
-    except:
-        return None
-
-def read_release_version():
-    try:
-        f = open(os.path.join(os.path.dirname(__file__), 'RELEASE-VERSION'), "r")
-        try:
-            version = f.readlines()[0]
-            return version.strip()
-        finally:
-            f.close()
-    except:
-        return None
-
-def write_release_version(version):
-    f = open(os.path.join(os.path.dirname(__file__), 'RELEASE-VERSION'), "w")
-    f.write("%s\n" % version)
-    f.close()
-
-def pep386adapt(version):
-    if version is not None and '-' in version:
-        # adapt git-describe version to be in line with PEP 386
-        # Break PEP 386 a bit here and append the Git hash
-        parts = version.split('-')
-        if len(parts) > 2:
-          version = '%s.post%s-%s' % (
-              parts[0], parts[1],
-              '-'.join(parts[2:])
-          )
-        return version
-    else:
-        return version
-
-def get_git_version():
-    # Read in the version that's currently in RELEASE-VERSION.
-    release_version = read_release_version()
-
-    # First try to get the current version using 'git describe'.
-    version = call_git_describe()
-
-    # Take off the leading if present.
-    if version[0] == 'v':
-      version = version[1:]
-
-    #adapt to PEP 386 compatible versioning scheme
-    version = pep386adapt(version)
-
-    # If that doesn't work, fall back on the value that's in
-    # RELEASE-VERSION.
-    if version is None:
-        version = release_version
-
-    # If we still don't have anything, that's an error.
-    if version is None:
-        raise ValueError("Cannot find the version number!")
-
-    # If the current version is different from what's in the
-    # RELEASE-VERSION file, update the file to be current.
-    if version != release_version:
-        write_release_version(version)
-
-    # Finally, return the current version.
-    return version
-
-VERSION = piksi_tools.version.VERSION
+from piksi_tools.version import VERSION
 
 CLASSIFIERS = [
   'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ PLATFORMS = [
 ]
 
 PACKAGE_DATA = { 'piksi_tools' : [
+  'RELEASE-VERSION',
   'console/settings.yaml',
   'console/images/fontawesome/download.svg',
   'console/images/fontawesome/exclamation-triangle.svg',


### PR DESCRIPTION
Versioning by hand has gotten old. Pulled the old versioning script back in - tweaked it to handle versioning with leading `v`. Have to replicate the logic in setup.py because setup.py can't take a dependency on library code - that was the initial issue we had with that approach. Identical code was added to https://github.com/swift-nav/libsbp/pull/154 - will take comments for both here.

/cc @fnoble @mookerji 