### PR TITLE
Versioned bootloader

### DIFF
--- a/piksi_tools/bootload.py
+++ b/piksi_tools/bootload.py
@@ -43,7 +43,8 @@ class Bootloader():
     self.stopped = False
     self.handshake_received = False
     self.version = None
-    self.sbp_protocol = None
+    # SBP version is unset in older devices.
+    self.sbp_version = 0
     self.link = link
     self.link.add_callback(self._deprecated_callback, SBP_MSG_BOOTLOADER_HANDSHAKE_DEPRECATED)
     self.link.add_callback(self._handshake_callback, SBP_MSG_BOOTLOADER_HANDSHAKE_DEVICE)
@@ -71,8 +72,7 @@ class Bootloader():
 
   def _handshake_callback(self, sbp_msg):
     self.version = sbp_msg.version
-    # Taking the sbp_protocol here, but continuing to use the bootloader version below.
-    self.sbp_protocol = sbp_msg.flags & 0xff
+    self.sbp_version = sbp_msg.flags & 0xff
     self.handshake_received = True
 
   def wait_for_handshake(self, timeout=None):
@@ -87,8 +87,8 @@ class Bootloader():
     return True
 
   def reply_handshake(self):
-    # < v2.0 of the bootloader, reuse single handshake message.
-    if self.version < "v2.0":
+    # < 0.45 of SBP protocol, reuse single handshake message.
+    if self.sbp_version < 45:
       self.link.send(SBP_MSG_BOOTLOADER_HANDSHAKE_DEPRECATED, '\x00')
     else:
       self.link.send(SBP_MSG_BOOTLOADER_HANDSHAKE_HOST, '\x00')
@@ -165,12 +165,14 @@ def main():
         piksi_bootloader.reply_handshake()
         print "received."
         print "Piksi Onboard Bootloader Version:", piksi_bootloader.version
+        if piksi_bootloader.sbp_version > 0:
+          print "Piksi Onboard SBP Protocol Version:", piksi_bootloader.sbp_version
 
         # Catch all other errors and exit cleanly.
         try:
           import flash
           with flash.Flash(link, flash_type=("STM" if use_stm else "M25"),
-                           version=piksi_bootloader.version) as piksi_flash:
+                           sbp_version=piksi_bootloader.sbp_version) as piksi_flash:
             if erase:
               for s in range(1,12):
                 print "\rErasing STM Sector", s,

--- a/piksi_tools/bootload.py
+++ b/piksi_tools/bootload.py
@@ -44,7 +44,7 @@ class Bootloader():
     self.handshake_received = False
     self.version = None
     self.link = link
-    self.link.add_callback(self._handshake_callback, SBP_MSG_BOOTLOADER_HANDSHAKE_DEVICE)
+    self.link.add_callback(self._handshake_callback, SBP_MSG_BOOTLOADER_HANDSHAKE_DEPRECATED)
 
   def __enter__(self):
     return self
@@ -55,7 +55,7 @@ class Bootloader():
 
   def stop(self):
     self.stopped = True
-    self.link.remove_callback(self._handshake_callback, SBP_MSG_BOOTLOADER_HANDSHAKE_DEVICE)
+    self.link.remove_callback(self._handshake_callback, SBP_MSG_BOOTLOADER_HANDSHAKE_DEPRECATED)
 
   def _handshake_callback(self, sbp_msg):
     if len(sbp_msg.payload)==1 and struct.unpack('B', sbp_msg.payload[0])==0:
@@ -80,7 +80,7 @@ class Bootloader():
   def reply_handshake(self):
     # < v2.0 of the bootloader, reuse single handshake message.
     if self.version < "v2.0":
-      self.link.send(SBP_MSG_BOOTLOADER_HANDSHAKE_DEVICE, '\x00')
+      self.link.send(SBP_MSG_BOOTLOADER_HANDSHAKE_DEPRECATED, '\x00')
     else:
       self.link.send(SBP_MSG_BOOTLOADER_HANDSHAKE_HOST, '\x00')
 

--- a/piksi_tools/bootload.py
+++ b/piksi_tools/bootload.py
@@ -44,7 +44,7 @@ class Bootloader():
     self.handshake_received = False
     self.version = None
     # SBP version is unset in older devices.
-    self.sbp_version = 0
+    self.sbp_version = (0, 0)
     self.link = link
     self.link.add_callback(self._deprecated_callback, SBP_MSG_BOOTLOADER_HANDSHAKE_DEPRECATED)
     self.link.add_callback(self._handshake_callback, SBP_MSG_BOOTLOADER_HANDSHAKE_DEVICE)
@@ -72,7 +72,7 @@ class Bootloader():
 
   def _handshake_callback(self, sbp_msg):
     self.version = sbp_msg.version
-    self.sbp_version = sbp_msg.flags & 0xff
+    self.sbp_version = ((sbp_msg.flags >> 8) & 0xF, sbp_msg.flags & 0xF)
     self.handshake_received = True
 
   def wait_for_handshake(self, timeout=None):
@@ -88,7 +88,7 @@ class Bootloader():
 
   def reply_handshake(self):
     # < 0.45 of SBP protocol, reuse single handshake message.
-    if self.sbp_version < 45:
+    if self.sbp_version < (0, 45):
       self.link.send(SBP_MSG_BOOTLOADER_HANDSHAKE_DEPRECATED, '\x00')
     else:
       self.link.send(SBP_MSG_BOOTLOADER_HANDSHAKE_HOST, '\x00')
@@ -165,7 +165,7 @@ def main():
         piksi_bootloader.reply_handshake()
         print "received."
         print "Piksi Onboard Bootloader Version:", piksi_bootloader.version
-        if piksi_bootloader.sbp_version > 0:
+        if piksi_bootloader.sbp_version > (0, 0):
           print "Piksi Onboard SBP Protocol Version:", piksi_bootloader.sbp_version
 
         # Catch all other errors and exit cleanly.

--- a/piksi_tools/bootload.py
+++ b/piksi_tools/bootload.py
@@ -43,8 +43,10 @@ class Bootloader():
     self.stopped = False
     self.handshake_received = False
     self.version = None
+    self.sbp_protocol = None
     self.link = link
-    self.link.add_callback(self._handshake_callback, SBP_MSG_BOOTLOADER_HANDSHAKE_DEPRECATED)
+    self.link.add_callback(self._deprecated_callback, SBP_MSG_BOOTLOADER_HANDSHAKE_DEPRECATED)
+    self.link.add_callback(self._handshake_callback, SBP_MSG_BOOTLOADER_HANDSHAKE_DEVICE)
 
   def __enter__(self):
     return self
@@ -55,15 +57,22 @@ class Bootloader():
 
   def stop(self):
     self.stopped = True
-    self.link.remove_callback(self._handshake_callback, SBP_MSG_BOOTLOADER_HANDSHAKE_DEPRECATED)
+    self.link.remove_callback(self._deprecated_callback, SBP_MSG_BOOTLOADER_HANDSHAKE_DEPRECATED)
+    self.link.remove_callback(self._handshake_callback, SBP_MSG_BOOTLOADER_HANDSHAKE_DEVICE)
 
-  def _handshake_callback(self, sbp_msg):
+  def _deprecated_callback(self, sbp_msg):
     if len(sbp_msg.payload)==1 and struct.unpack('B', sbp_msg.payload[0])==0:
       # == v0.1 of the bootloader, returns hardcoded version number 0.
       self.version = "v0.1"
     else:
       # > v0.1 of the bootloader, returns git commit string.
       self.version = sbp_msg.payload[:]
+    self.handshake_received = True
+
+  def _handshake_callback(self, sbp_msg):
+    self.version = sbp_msg.version
+    # Taking the sbp_protocol here, but continuing to use the bootloader version below.
+    self.sbp_protocol = sbp_msg.flags & 0xff
     self.handshake_received = True
 
   def wait_for_handshake(self, timeout=None):

--- a/piksi_tools/flash.py
+++ b/piksi_tools/flash.py
@@ -242,7 +242,7 @@ class Flash():
       Handler to send messages to Piksi over and register callbacks with.
     flash_type : string
       Which Piksi flash to interact with ("M25" or "STM").
-    sbp_version : int
+    sbp_version : (int, int)
       SBP protocol version, used to select messages to send.
 
     Returns
@@ -388,7 +388,7 @@ class Flash():
     msg_buf += struct.pack("B", len(data))
     self.inc_n_queued_ops()
     # < 0.45 of SBP protocol, reuse single flash message.
-    if self.sbp_version < 45:
+    if self.sbp_version < (0, 45):
       self.link.send(SBP_MSG_FLASH_DONE, msg_buf + data)
     else:
       self.link.send(SBP_MSG_FLASH_PROGRAM, msg_buf + data)
@@ -409,7 +409,7 @@ class Flash():
     msg_buf += struct.pack("B", length)
     self.inc_n_queued_ops()
     # < 0.45 of SBP protocol, reuse single read message.
-    if self.sbp_version < 45:
+    if self.sbp_version < (0, 45):
       self.link.send(SBP_MSG_FLASH_READ_DEVICE, msg_buf)
     else:
       self.link.send(SBP_MSG_FLASH_READ_HOST, msg_buf)

--- a/piksi_tools/flash.py
+++ b/piksi_tools/flash.py
@@ -231,7 +231,7 @@ def _m25_write_status(self, sr):
 
 class Flash():
 
-  def __init__(self, link, flash_type, version):
+  def __init__(self, link, flash_type, sbp_version):
     """
     Object representing either of the two flashes (STM/M25) on the Piksi,
     including methods to erase, program, and read.
@@ -242,8 +242,8 @@ class Flash():
       Handler to send messages to Piksi over and register callbacks with.
     flash_type : string
       Which Piksi flash to interact with ("M25" or "STM").
-    version : string
-      Piksi bootloader version, used to select messages to send.
+    sbp_version : int
+      SBP protocol version, used to select messages to send.
 
     Returns
     -------
@@ -255,7 +255,7 @@ class Flash():
     self.status = ''
     self.link = link
     self.flash_type = flash_type
-    self.version = version
+    self.sbp_version = sbp_version
     # IntelHex object to store read flash data in that was read from device.
     self._read_callback_ihx = IntelHex()
     self.link.add_callback(self._done_callback, SBP_MSG_FLASH_DONE)
@@ -387,8 +387,8 @@ class Flash():
     msg_buf += struct.pack("<I", address)
     msg_buf += struct.pack("B", len(data))
     self.inc_n_queued_ops()
-    # < v2.0 of the bootloader, reuse single flash message.
-    if self.version < "v2.0":
+    # < 0.45 of SBP protocol, reuse single flash message.
+    if self.sbp_version < 45:
       self.link.send(SBP_MSG_FLASH_DONE, msg_buf + data)
     else:
       self.link.send(SBP_MSG_FLASH_PROGRAM, msg_buf + data)
@@ -408,8 +408,8 @@ class Flash():
     msg_buf += struct.pack("<I", address)
     msg_buf += struct.pack("B", length)
     self.inc_n_queued_ops()
-    # < v2.0 of the bootloader, reuse single read message.
-    if self.version < "v2.0":
+    # < 0.45 of SBP protocol, reuse single read message.
+    if self.sbp_version < 45:
       self.link.send(SBP_MSG_FLASH_READ_DEVICE, msg_buf)
     else:
       self.link.send(SBP_MSG_FLASH_READ_HOST, msg_buf)

--- a/piksi_tools/stm_unique_id.py
+++ b/piksi_tools/stm_unique_id.py
@@ -19,22 +19,31 @@ from sbp.client.handler import *
 
 class STMUniqueID:
 
-  def __init__(self, link, version):
+  def __init__(self, link):
+    self.heartbeat_received = False
     self.unique_id_returned = False
+    # SBP version is unset in older devices.
+    self.sbp_version = 0
     self.unique_id = None
     self.link = link
-    self.version = version
+    link.add_callback(self.receive_heartbeat, SBP_MSG_HEARTBEAT)
     link.add_callback(self.receive_stm_unique_id_callback, SBP_MSG_STM_UNIQUE_ID_DEVICE)
+
+  def receive_heartbeat(self, sbp_msg):
+    self.heartbeat_received = True
+    self.sbp_version = (sbp_msg.flags >> 8) & 0xFF
 
   def receive_stm_unique_id_callback(self,sbp_msg):
     self.unique_id_returned = True
     self.unique_id = struct.unpack('<12B',sbp_msg.payload)
 
   def get_id(self):
+    while not self.heartbeat_received:
+      time.sleep(0.1)
     self.unique_id_returned = False
     self.unique_id = None
-    # < v2.0 of the bootloader, reuse single stm message.
-    if self.version < "v2.0":
+    # < 45 of the bootloader, reuse single stm message.
+    if self.sbp_version < 45:
       self.link.send(SBP_MSG_STM_UNIQUE_ID_DEVICE, struct.pack("<I",0))
     else:
       self.link.send(SBP_MSG_STM_UNIQUE_ID_HOST, struct.pack("<I",0))
@@ -57,9 +66,6 @@ def get_args():
   parser.add_argument("-b", "--baud",
                       default=[serial_link.SERIAL_BAUD], nargs=1,
                       help="specify the baud rate to use.")
-  parser.add_argument("-v", "--version",
-                      default=[None], nargs=1,
-                      help="bootloader version to use.")
   return parser.parse_args()
 
 def main():
@@ -69,12 +75,11 @@ def main():
   args = get_args()
   port = args.port[0]
   baud = args.baud[0]
-  version = args.version[0]
   # Driver with context
   with serial_link.get_driver(args.ftdi, port, baud) as driver:
     with Handler(driver.read, driver.write) as link:
       link.start()
-      unique_id = STMUniqueID(link, version).get_id()
+      unique_id = STMUniqueID(link).get_id()
       print "STM Unique ID =", "0x" + ''.join(["%02x" % (b) for b in unique_id])
 
 if __name__ == "__main__":

--- a/piksi_tools/stm_unique_id.py
+++ b/piksi_tools/stm_unique_id.py
@@ -23,7 +23,7 @@ class STMUniqueID:
     self.heartbeat_received = False
     self.unique_id_returned = False
     # SBP version is unset in older devices.
-    self.sbp_version = 0
+    self.sbp_version = (0, 0)
     self.unique_id = None
     self.link = link
     link.add_callback(self.receive_heartbeat, SBP_MSG_HEARTBEAT)
@@ -31,7 +31,7 @@ class STMUniqueID:
 
   def receive_heartbeat(self, sbp_msg):
     self.heartbeat_received = True
-    self.sbp_version = (sbp_msg.flags >> 8) & 0xFF
+    self.sbp_version = ((sbp_msg.flags >> 8) & 0xF, sbp_msg.flags & 0xF)
 
   def receive_stm_unique_id_callback(self,sbp_msg):
     self.unique_id_returned = True
@@ -42,8 +42,8 @@ class STMUniqueID:
       time.sleep(0.1)
     self.unique_id_returned = False
     self.unique_id = None
-    # < 45 of the bootloader, reuse single stm message.
-    if self.sbp_version < 45:
+    # < 0.45 of the bootloader, reuse single stm message.
+    if self.sbp_version < (0, 45):
       self.link.send(SBP_MSG_STM_UNIQUE_ID_DEVICE, struct.pack("<I",0))
     else:
       self.link.send(SBP_MSG_STM_UNIQUE_ID_HOST, struct.pack("<I",0))

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ coverage==3.7.1
 flake8==2.3.0
 futures==2.2.0
 pep8==1.5.7
-sbp==0.42
+sbp==0.44
 pytest==2.6.4
 pytest-cov==1.8.1
 tox==1.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ coverage==3.7.1
 flake8==2.3.0
 futures==2.2.0
 pep8==1.5.7
-sbp==0.44
+sbp==0.45
 pytest==2.6.4
 pytest-cov==1.8.1
 tox==1.8.1


### PR DESCRIPTION
Brought in the new SBP and setup new handler for new bootloader message. Not actually using `sbp_protocol` yet. Not clear exactly where explicitly it needs to be used. Still using the bootloader version everywhere instead.

/cc @cbeighley 

<!---
@huboard:{"order":403.080078125}
-->
