### PR TITLE
Generate settings as JSON file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,4 +68,4 @@ RELEASE-VERSION
 /piksi_tools/pyinstaller/dist
 
 *.csv
-settings.yaml
+diagnostics.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ RELEASE-VERSION
 /piksi_tools/pyinstaller/dist
 
 *.csv
+settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -68,4 +68,4 @@ RELEASE-VERSION
 /piksi_tools/pyinstaller/dist
 
 *.csv
-settings.json
+settings.yaml

--- a/piksi_tools/diagnostics.py
+++ b/piksi_tools/diagnostics.py
@@ -28,7 +28,8 @@ class Diagnostics(object):
   The :class:`Diagnostics` class collects devices diagnostics.
   """
   def __init__(self, link):
-    self.settings = {}
+    self.diagnostics = {}
+    self.diagnostics['settings'] = {}
     self.settings_received = False
     self.link = link
     self.link.add_callback(self._read_callback, SBP_MSG_SETTINGS_READ_BY_INDEX)
@@ -41,9 +42,9 @@ class Diagnostics(object):
       self.settings_received = True
     else:
       section, setting, value, format_type = sbp_msg.payload[2:].split('\0')[:4]
-      if not self.settings.has_key(section):
-        self.settings[section] = {}
-      self.settings[section][setting] = value
+      if not self.diagnostics['settings'].has_key(section):
+        self.diagnostics['settings'][section] = {}
+      self.diagnostics['settings'][section][setting] = value
 
       index = struct.unpack('<H', sbp_msg.payload[:2])[0]
       self.link.send_msg(MsgSettingsReadByIndex(index=index+1))
@@ -79,9 +80,9 @@ def main():
   # Driver with context
   with serial_link.get_driver(args.ftdi, port, baud) as driver:
     with Handler(driver.read, driver.write) as link:
-      settings = Diagnostics(link).settings
+      diagnostics = Diagnostics(link).diagnostics
       with open(diagnostics_filename, 'w') as diagnostics_file:
-        yaml.dump(settings, diagnostics_file, default_flow_style=False)
+        yaml.dump(diagnostics, diagnostics_file, default_flow_style=False)
 
 if __name__ == "__main__":
   main()

--- a/piksi_tools/diagnostics.py
+++ b/piksi_tools/diagnostics.py
@@ -19,13 +19,13 @@ from sbp.settings       import *
 from sbp.msg            import *
 from sbp.logging        import SBP_MSG_PRINT
 
-SETTINGS_FILENAME = "settings.yaml"
+DIAGNOSTICS_FILENAME = "diagnostics.yaml"
 
-class Settings(object):
+class Diagnostics(object):
   """
-  Settings
+  Diagnostics
 
-  The :class:`Settings` class collects devices settings.
+  The :class:`Diagnostics` class collects devices diagnostics.
   """
   def __init__(self, link):
     self.settings = {}
@@ -63,9 +63,9 @@ def get_args():
   parser.add_argument("-b", "--baud",
                       default=[serial_link.SERIAL_BAUD], nargs=1,
                       help="specify the baud rate to use.")
-  parser.add_argument("-o", "--settings-filename",
-                      default=[SETTINGS_FILENAME], nargs=1,
-                      help="file to write settings to.")
+  parser.add_argument("-o", "--diagnostics-filename",
+                      default=[DIAGNOSTICS_FILENAME], nargs=1,
+                      help="file to write diagnostics to.")
   return parser.parse_args()
 
 def main():
@@ -75,13 +75,13 @@ def main():
   args = get_args()
   port = args.port[0]
   baud = args.baud[0]
-  settings_filename = args.settings_filename[0]
+  diagnostics_filename = args.diagnostics_filename[0]
   # Driver with context
   with serial_link.get_driver(args.ftdi, port, baud) as driver:
     with Handler(driver.read, driver.write) as link:
-      settings = Settings(link).settings
-      with open(settings_filename, 'w') as settings_file:
-        yaml.dump(settings, settings_file, default_flow_style=False)
+      settings = Diagnostics(link).settings
+      with open(diagnostics_filename, 'w') as diagnostics_file:
+        yaml.dump(settings, diagnostics_file, default_flow_style=False)
 
 if __name__ == "__main__":
   main()

--- a/piksi_tools/settings.py
+++ b/piksi_tools/settings.py
@@ -12,14 +12,14 @@
 import serial_link
 import time
 import struct
-import json
+import yaml
 
 from sbp.client.handler import *
 from sbp.settings       import *
 from sbp.msg            import *
 from sbp.logging        import SBP_MSG_PRINT
 
-SETTINGS_FILENAME = "settings.json"
+SETTINGS_FILENAME = "settings.yaml"
 
 class Settings(object):
   """
@@ -81,7 +81,7 @@ def main():
     with Handler(driver.read, driver.write) as link:
       settings = Settings(link).settings
       with open(settings_filename, 'w') as settings_file:
-        json.dump(settings, settings_file, sort_keys=True, indent=2, separators=(',', ': '))
+        yaml.dump(settings, settings_file, default_flow_style=False)
 
 if __name__ == "__main__":
   main()

--- a/piksi_tools/settings.py
+++ b/piksi_tools/settings.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+# Copyright (C) 2015 Swift Navigation Inc.
+# Contact: Colin Beighley <colin@swift-nav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+import serial_link
+import time
+import struct
+import json
+
+from sbp.client.handler import *
+from sbp.settings       import *
+from sbp.msg            import *
+from sbp.logging        import SBP_MSG_PRINT
+
+SETTINGS_FILENAME = "settings.json"
+
+class Settings(object):
+  """
+  Settings
+
+  The :class:`Settings` class collects devices settings.
+  """
+  def __init__(self, link):
+    self.settings = {}
+    self.settings_received = False
+    self.link = link
+    self.link.add_callback(self._read_callback, SBP_MSG_SETTINGS_READ_BY_INDEX)
+    self.link.send_msg(MsgSettingsReadByIndex(index=0))
+    while not self.settings_received:
+      time.sleep(0.1)
+
+  def _read_callback(self, sbp_msg):
+    if not sbp_msg.payload:
+      self.settings_received = True
+    else:
+      section, setting, value, format_type = sbp_msg.payload[2:].split('\0')[:4]
+      if not self.settings.has_key(section):
+        self.settings[section] = {}
+      self.settings[section][setting] = value
+
+      index = struct.unpack('<H', sbp_msg.payload[:2])[0]
+      self.link.send_msg(MsgSettingsReadByIndex(index=index+1))
+
+def get_args():
+  """
+  Get and parse arguments.
+  """
+  import argparse
+  parser = argparse.ArgumentParser(description='Acquisition Monitor')
+  parser.add_argument("-f", "--ftdi",
+                      help="use pylibftdi instead of pyserial.",
+                      action="store_true")
+  parser.add_argument('-p', '--port',
+                      default=[serial_link.SERIAL_PORT], nargs=1,
+                      help='specify the serial port to use.')
+  parser.add_argument("-b", "--baud",
+                      default=[serial_link.SERIAL_BAUD], nargs=1,
+                      help="specify the baud rate to use.")
+  parser.add_argument("-o", "--settings-filename",
+                      default=[SETTINGS_FILENAME], nargs=1,
+                      help="file to write settings to.")
+  return parser.parse_args()
+
+def main():
+  """
+  Get configuration, get driver, and build handler and start it.
+  """
+  args = get_args()
+  port = args.port[0]
+  baud = args.baud[0]
+  settings_filename = args.settings_filename[0]
+  # Driver with context
+  with serial_link.get_driver(args.ftdi, port, baud) as driver:
+    with Handler(driver.read, driver.write) as link:
+      settings = Settings(link).settings
+      with open(settings_filename, 'w') as settings_file:
+        json.dump(settings, settings_file, sort_keys=True, indent=2, separators=(',', ': '))
+
+if __name__ == "__main__":
+  main()


### PR DESCRIPTION
Simple utility to generate our settings as a JSON file for consumption by other tooling.

Generated JSON looks like:

```json
{
  "ext_events": {
    "edge_trigger": "None"
  },
  "float_kf": {
    "amb_init_var": "1e+25",
    "code_var": "40000",
    "new_amb_var": "1e+25",
    "phase_var": "0.0144"
  },
  "frontend": {
    "antenna_selection": "External"
  },
  "iar": {
    "code_var": "40000",
    "phase_var": "0.0144"
  },
  "sbp": {
    "obs_msg_max_size": "104"
  },
  "simulator": {
    "base_ecef_x": "-2700303.10144",
    "base_ecef_y": "-4292474.39651",
    "base_ecef_z": "3855434.34087",
    "cn0_sigma": "0.300000011921",
    "enabled": "False",
    "mode_mask": "15",
    "num_sats": "9",
    "phase_sigma": "0.0299999993294",
    "pos_sigma": "1.5",
    "pseudorange_sigma": "4",
    "radius": "100",
    "speed": "4",
    "speed_sigma": "0.15000000596"
  },
  "solution": {
    "dgnss_filter": "Fixed",
    "dgnss_solution_mode": "Low Latency",
    "known_baseline_d": "0",
    "known_baseline_e": "0",
    "known_baseline_n": "0",
    "output_every_n_obs": "2",
    "soln_freq": "10"
  },
  "surveyed_position": {
    "broadcast": "False",
    "surveyed_alt": "0",
    "surveyed_lat": "0",
    "surveyed_lon": "0"
  },
  "system_info": {
    "firmware_built": "Jun 16 2015 00:15:21",
    "firmware_version": "v0.17",
    "hw_revision": "piksi_2.3.1",
    "nap_channels": "11",
    "nap_fft_index_bits": "13",
    "nap_version": "v0.13",
    "serial_number": "36828"
  },
  "system_monitor": {
    "heartbeat_period_milliseconds": "1000",
    "watchdog": "True"
  },
  "telemetry_radio": {
    "configuration_string": "AT&F,ATS1=115,ATS2=128,ATS5=0,AT&W,ATZ"
  },
  "track": {
    "iq_output_mask": "0"
  },
  "uart_ftdi": {
    "baudrate": "1000000",
    "mode": "SBP",
    "sbp_message_mask": "65535"
  },
  "uart_uarta": {
    "baudrate": "115200",
    "configure_telemetry_radio_on_boot": "True",
    "mode": "SBP",
    "sbp_message_mask": "64"
  },
  "uart_uartb": {
    "baudrate": "115200",
    "configure_telemetry_radio_on_boot": "True",
    "mode": "SBP",
    "sbp_message_mask": "65280"
  }
}
```

All strings because there's no type information.

/cc @fnoble @mookerji @denniszollo 