### PR TITLE
Script to check firmware/nap settings on test.

### DIFF
--- a/piksi_tools/diagnostics.py
+++ b/piksi_tools/diagnostics.py
@@ -73,9 +73,37 @@ class Diagnostics(object):
       if not self.diagnostics['settings'].has_key(section):
         self.diagnostics['settings'][section] = {}
       self.diagnostics['settings'][section][setting] = value
-
       index = struct.unpack('<H', sbp_msg.payload[:2])[0]
       self.link.send_msg(MsgSettingsReadByIndex(index=index+1))
+
+
+def parse_device_details_yaml(device_details):
+  """Parse from yaml string the device settings.
+
+  """
+  return yaml.load(device_details)['settings']['system_info']
+
+
+def check_diagnostics(diagnostics_filename, version):
+  """Check that Piksi's firmware/nap settings are properly set.
+
+  Given a diagnostics_filename output and an expected firmware/NAP
+  versions (via a Yaml string), returns True if expected fw/nap are
+  properly loaded.
+
+  """
+  if version is None:
+    raise Exception("Empty version string!")
+  parsed = yaml.load(version)
+  fw = parsed.get('fw', None)
+  nap = parsed.get('hdl', None)
+  with open(diagnostics_filename, 'r+') as f:
+    details = parse_device_details_yaml(f.read())
+    firmware_version = details.get('firmware_version', None)
+    nap_version = details.get('nap_version', None)
+    return (firmware_version and nap_version) \
+        and (firmware_version == fw and nap_version == nap)
+
 
 def get_args():
   """

--- a/piksi_tools/testing/check_device_details.py
+++ b/piksi_tools/testing/check_device_details.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+# Copyright (C) 2015 Swift Navigation Inc.
+# Contact: Bhaskar Mookerji <mookerji@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+import piksi_tools.diagnostics as d
+
+
+def get_args():
+  import argparse
+  parser = argparse.ArgumentParser(description='Check Piksi firmware versions')
+  parser.add_argument("-d",
+                      "--diagnostics-filename",
+                      nargs=1,
+                      help="Settings YAML file")
+  parser.add_argument("-v",
+                      "--version-filename",
+                      nargs=1,
+                      help="Name of git describe VERSION file")
+  return parser.parse_args()
+
+
+def main():
+  import os, sys
+  args = get_args()
+  diagnostics_filename = args.diagnostics_filename[0]
+  assert os.path.exists(diagnostics_filename), \
+    "Your hovercraft is full of fail, %s does not exist!" % diagnostics_filename
+  version_filename = args.version_filename[0]
+  assert os.path.exists(version_filename), \
+    "Your hovercraft is full of fail, %s does not exist!" % version_filename
+  version = open(version_filename, 'r+').read()
+  if not d.check_diagnostics(diagnostics_filename, version):
+    sys.exit(1)
+
+if __name__ == "__main__":
+  main()

--- a/tests/data/device_details.yaml
+++ b/tests/data/device_details.yaml
@@ -1,0 +1,14 @@
+settings:
+  system_info:
+    firmware_built: Jun 17 2015 23:54:08
+    firmware_version: v0.17-27-ge2c1aac
+    hw_revision: piksi_2.3.1
+    nap_channels: '11'
+    nap_fft_index_bits: '13'
+    nap_version: v0.13-rc0
+    serial_number: '1233'
+  system_monitor:
+    watchdog: 'True'
+versions:
+  bootloader: v1.2
+  sbp: 0

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+# Copyright (C) 2015 Swift Navigation Inc.
+# Contact: Bhaskar Mookerji <mookerji@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+import piksi_tools.diagnostics as d
+import pytest
+
+
+def test_diag_check():
+  details = 'tests/data/device_details.yaml'
+  version = 'fw: v0.17-27-ge2c1aac\nhdl: v0.13-rc0\n'
+  assert d.check_diagnostics(details, version)
+  version = 'fw: v0.17-27-deadbeef\nhdl: v0.13-rc0\n'
+  assert not d.check_diagnostics(details, version)
+  version = 'fw: v0.17-27-ge2c1aac\nhdl: v0.13-defecated\n'
+  assert not d.check_diagnostics(details, version)
+  with pytest.raises(Exception):
+    assert not d.check_diagnostics(details, None)


### PR DESCRIPTION
HITL test doesn't always bootload the right firmware. Testing scripts
now check versions and exit early if versions aren't what we expected.

Required for:
https://github.com/swift-nav/sbp_log_analysis/issues/196

/cc @mfine @cbeighley @denniszollo