### PR TITLE
CONSOLE: hide expert settings by default

### DIFF
--- a/piksi_tools/console/console.py
+++ b/piksi_tools/console/console.py
@@ -58,6 +58,8 @@ def get_args():
                       action="store_true")
   parser.add_argument('-t', '--toolkit', nargs=1, default=[None],
                       help="specify the TraitsUI toolkit to use, either 'wx' or 'qt4'.")
+  parser.add_argument('-e', '--expert', action='store_true',
+                      help="Show expert settings.")
   return parser.parse_args()
 
 args = get_args()
@@ -274,7 +276,8 @@ class SwiftConsole(HasTraits):
       settings_read_finished_functions.append(update_serial)
 
       self.settings_view = \
-          SettingsView(self.link, settings_read_finished_functions)
+          SettingsView(self.link, settings_read_finished_functions,
+                       hide_expert = not args.expert)
       self.update_view.settings = self.settings_view.settings
 
       self.python_console_env = {

--- a/piksi_tools/console/settings.yaml
+++ b/piksi_tools/console/settings.yaml
@@ -63,6 +63,7 @@
 
 - group: float_kf
   name: phase_var
+  expert: true
   type: Double
   units: cycles^2
   default value: '0.0144'
@@ -76,6 +77,7 @@
 
 - group: float_kf
   name: code_var
+  expert: true
   type: Double
   units: meters^2
   default value: '40000'
@@ -89,6 +91,7 @@
 
 - group: float_kf
   name: amb_init_var
+  expert: true
   type: Double
   units: non dimensional
   default value: '1.00E+25'
@@ -102,6 +105,7 @@
 
 - group: float_kf
   name: new_amb_var
+  expert: true
   type: Double
   units: non dimensional
   default value: '1.00E+25'
@@ -130,6 +134,7 @@
 
 - group: iar
   name: phase_var
+  expert: true
   type: double
   units: cycles^2
   default value: '0.0144'
@@ -143,6 +148,7 @@
 
 - group: iar
   name: code_var
+  expert: true
   type: double
   units: meters^2
   default value: '40000'
@@ -337,6 +343,7 @@
 
 - group: solution
   name: dgnss_filter
+  expert: true
   type: enum
   units:
   default value: Fixed
@@ -606,3 +613,41 @@
   enumerated possible values: 
   Description: Unused
   Notes:
+
+- group: track
+  name: track_cn0_threshold
+  type: Double
+  units: db-Hz
+  default value: '33'
+  Description: C/N0 threshold for tracking and navigation.
+  Notes: If the estimated C/N0 drops below this even momentarily,
+         the integer ambiguity for that channel will be reinitialized.
+         If the estimated C/N0 drops below this for a certain duration,
+         the signal will be considered lost altogether and tracking
+         will stop.
+
+- group: track
+  name: loop_params
+  type: string
+  units: 
+  default value: '(1 ms, (1, 0.7, 1, 1540), (10, 0.7, 1, 5)), (5 ms, (1, 0.7, 1, 1540), (50, 0.7, 1, 0))'
+  Description: Tracking loop filter parameters
+  Notes: "'<LOOP_PARAMS_STAGE1>[, <LOOP_PARAMS_STAGE2>]'
+
+
+    where <LOOP_PARAMS_STAGEn> =
+
+    (<COHERENT_MS> ms, (CODE_BW, CODE_ZETA, CODE_K, CARR_TO_CODE),
+
+                       (CARR_BW, CARR_ZETA, CARR_K, FLL_AID_GAIN))
+
+
+    LOOP_PARAMS_STAGE1 will be used until navigation bit synchronization
+    is achieved, after which LOOP_PARAMS_STAGE2 will be used.
+
+
+    COHERENT_MS must be a factor of 20, and must be 1 for LOOP_PARAMS_STAGE1.
+
+
+    CARR_TO_CODE should be 0 (carrier aiding disabled) or 1540 (ratio of
+    GPS L1 C/A carrier freq to code freq)."

--- a/piksi_tools/console/settings_view.py
+++ b/piksi_tools/console/settings_view.py
@@ -90,6 +90,7 @@ class Setting(SettingBase):
     self.value = value
     self.ordering = ordering
     self.settings = settings
+    self.expert = settings.settings_yaml.get_field(section, name, 'expert')
     self.description = settings.settings_yaml.get_field(section,
                                                            name, 'Description')
     self.notes = settings.settings_yaml.get_field(section, name, 'Notes')
@@ -230,11 +231,14 @@ class SettingsView(HasTraits):
       sections = sorted(self.settings.keys())
 
       for sec in sections:
-        if self.hide_expert and sec.startswith("expert"):
-          continue
-        self.settings_list.append(SectionHeading(sec))
+        this_section = []
         for name, setting in sorted(self.settings[sec].iteritems(), key=lambda (n, s): s.ordering):
-          self.settings_list.append(setting)
+          if not (self.hide_expert and setting.expert):
+            this_section.append(setting)
+        if this_section:
+          self.settings_list.append(SectionHeading(sec))
+          self.settings_list += this_section
+
 
       for cb in self.read_finished_functions:
         if self.gui_mode:

--- a/piksi_tools/console/settings_view.py
+++ b/piksi_tools/console/settings_view.py
@@ -223,11 +223,15 @@ class SettingsView(HasTraits):
 
   def settings_read_by_index_callback(self, sbp_msg):
     if not sbp_msg.payload:
+      # Settings output from Piksi is terminated by an empty message.
+      # Bundle up our list and display it.
       self.settings_list = []
 
       sections = sorted(self.settings.keys())
 
       for sec in sections:
+        if self.hide_expert and sec.startswith("expert"):
+          continue
         self.settings_list.append(SectionHeading(sec))
         for name, setting in sorted(self.settings[sec].iteritems(), key=lambda (n, s): s.ordering):
           self.settings_list.append(setting)
@@ -287,10 +291,11 @@ class SettingsView(HasTraits):
           '%s\0%s\0%s\0' % (section, name, value))
 
   def __init__(self, link, read_finished_functions=[],
-               name_of_yaml_file="settings.yaml", gui_mode=True):
+               name_of_yaml_file="settings.yaml", gui_mode=True, hide_expert=False):
 
     super(SettingsView, self).__init__()
 
+    self.hide_expert = hide_expert
     self.gui_mode = gui_mode
     self.enumindex = 0
     self.settings = {}


### PR DESCRIPTION
cc @denniszollo @gsmcmullin @fnoble  
Any setting category beginning with "expert" will be hidden unless -e is passed on the console command line.