### PR TITLE
Strip the newline on the payload before processing

### DIFF
--- a/piksi_tools/console/settings_view.py
+++ b/piksi_tools/console/settings_view.py
@@ -254,7 +254,7 @@ class SettingsView(HasTraits):
       self.settings_display_setup()
       return
 
-    section, setting, value, format_type = sbp_msg.payload[2:].split('\0')[:4]
+    section, setting, value, format_type = sbp_msg.payload.rstrip('\n')[2:].split('\0')[:4]
     self.ordering_counter += 1
 
     if format_type == '':


### PR DESCRIPTION
Strip out the newline before processing the payload. https://github.com/swift-nav/piksi_firmware/pull/490.

/cc @denniszollo @fnoble @mookerji 