### PR TITLE
CONSOLE: show_labels not show_label, fix startup crash

### DIFF
--- a/piksi_tools/console/console.py
+++ b/piksi_tools/console/console.py
@@ -193,7 +193,7 @@ class SwiftConsole(HasTraits):
             'python_console_env', style='custom',
             label='Python Console', editor=ShellEditor()),
           label='Advanced',
-          show_label=False
+          show_labels=False
          ),
         show_labels=False
       ),


### PR DESCRIPTION
@denniszollo I haven't looked deeply into what's going on here but one of your recent changes caused the console to crash on startup for me, with the following message:
```
henry@henn0:~/swift/piksi_tools$ python -m piksi_tools.console.console -u -e -p /dev/ttyUSB0
Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/home/henry/swift/piksi_tools/piksi_tools/console/console.py", line 146, in <module>
    class SwiftConsole(HasTraits):
  File "/home/henry/swift/piksi_tools/piksi_tools/console/console.py", line 196, in SwiftConsole
    show_label=False
  File "/usr/local/lib/python2.7/dist-packages/traitsui/group.py", line 210, in __init__
    super( ViewSubElement, self ).__init__( **traits )
traits.trait_errors.TraitError: Cannot set the undefined 'show_label' attribute of a 'Tabbed' object.
```

This fixes the issue for me.