### PR TITLE
Console list tweaks

### DIFF
--- a/piksi_tools/console/console.py
+++ b/piksi_tools/console/console.py
@@ -212,7 +212,8 @@ class SwiftConsole(HasTraits):
           Item('clear_button', show_label=False, width=8, height=8),
           Item('', label='Console Log', emphasized=True),
           Spring(),
-          UItem('log_level_filter', style='simple', padding=0, height=8),
+          UItem('log_level_filter', style='simple', padding=0, height=8, show_label=True,
+                tooltip='Shows log levels up to and including the selected level of severity.'),
         ),
         Item(
           'console_output',

--- a/piksi_tools/console/console.py
+++ b/piksi_tools/console/console.py
@@ -238,14 +238,18 @@ class SwiftConsole(HasTraits):
 
   def print_message_callback(self, sbp_msg, **metadata):
     try:
-      self.console_output.write_level(sbp_msg.payload.encode('ascii', 'ignore'),
-                                      str_to_log_level(msg.split(':')[0]))
+      encoded = sbp_msg.payload.encode('ascii', 'ignore')
+      for eachline in reversed(encoded.split('\n')):
+        self.console_output.write_level(eachline,
+                                        str_to_log_level(msg.split(':')[0]))
     except UnicodeDecodeError:
       print "Critical Error encoding the serial stream as ascii."
 
   def log_message_callback(self, sbp_msg, **metadata):
     try:
-      self.console_output.write_level(sbp_msg.text.encode('ascii', 'ignore'), sbp_msg.level)
+      encoded = sbp_msg.text.encode('ascii', 'ignore')
+      for eachline in reversed(encoded.split('\n')):
+        self.console_output.write_level(eachline, sbp_msg.level)
     except UnicodeDecodeError:
       print "Critical Error encoding the serial stream as ascii."
 

--- a/piksi_tools/console/console.py
+++ b/piksi_tools/console/console.py
@@ -47,6 +47,9 @@ def get_args():
   parser.add_argument("-o", "--log-filename",
                       default=[serial_link.LOG_FILENAME], nargs=1,
                       help="file to log output to.")
+  parser.add_argument("-i", "--initloglevel",
+                      default=[None], nargs=1,
+                      help="Set log level filter.")
   parser.add_argument("-r", "--reset",
                       action="store_true",
                       help="reset device after connection.")
@@ -265,12 +268,13 @@ class SwiftConsole(HasTraits):
   def _clear_button_fired(self):
     self.console_output.clear()
 
-  def __init__(self, link, update):
+  def __init__(self, link, update, log_level_filter):
     self.console_output = OutputList()
     self.console_output.write("Console: starting...")
     sys.stdout = self.console_output
     sys.stderr = self.console_output
-    self.log_level_filter = DEFAULT_LOG_LEVEL_FILTER
+    self.log_level_filter = log_level_filter
+    self.console_output.log_level_filter = str_to_log_level(log_level_filter)
     try:
       self.link = link
       self.link.add_callback(self.print_message_callback, SBP_MSG_PRINT_DEP)
@@ -361,7 +365,10 @@ with serial_link.get_driver(args.ftdi, port, baud) as driver:
       link.add_callback(logger)
       if args.reset:
         link(MsgReset())
-      console = SwiftConsole(link, update=args.update)
+      log_level_filter = DEFAULT_LOG_LEVEL_FILTER
+      if args.initloglevel[0]:
+        log_level_filter = args.initloglevel[0]
+      console = SwiftConsole(link, update=args.update, log_level_filter=log_level_filter)
       console.configure_traits()
 
 

--- a/piksi_tools/console/console.py
+++ b/piksi_tools/console/console.py
@@ -216,7 +216,7 @@ class SwiftConsole(HasTraits):
           Item('', label='Console Log', emphasized=True),
           Spring(),
           UItem('log_level_filter', style='simple', padding=0, height=8, show_label=True,
-                tooltip='Shows log levels up to and including the selected level of severity.'),
+                tooltip='Show log levels up to and including the selected level of severity.\nThe CONSOLE log level is always visible.'),
         ),
         Item(
           'console_output',

--- a/piksi_tools/console/output_list.py
+++ b/piksi_tools/console/output_list.py
@@ -291,7 +291,8 @@ class OutputList(HasTraits):
     view = \
       View(
           UItem('filtered_list',
-                editor = TabularEditor(adapter=LogItemOutputListAdapter(), editable=False))
+                editor = TabularEditor(adapter=LogItemOutputListAdapter(), editable=False,
+                                       vertical_lines=False, horizontal_lines=False))
         )
     return view
 

--- a/piksi_tools/console/output_list.py
+++ b/piksi_tools/console/output_list.py
@@ -136,9 +136,9 @@ class LogItem(HasTraits):
     Timestamp initailzies to current system time
     msg is passed in by the user
     """
+    # set constructor params
     self.log_level = level
-    # remove line breaks from the message
-    self.msg = msg.rstrip('\n')
+    self.msg = msg
     # set timestamp
     self.timestamp = time.strftime("%b %d %Y %H:%M:%S")
 
@@ -205,7 +205,7 @@ class OutputList(HasTraits):
       string to cast as LogItem and write to tables
     """
 
-    if not s.isspace():
+    if s and not s.isspace():
       log = LogItem(s, CONSOLE_LOG_LEVEL)
       if self.paused:
         self.append_truncate(self._paused_buffer, log)
@@ -225,13 +225,14 @@ class OutputList(HasTraits):
     level : int
       Integer log level to use when creating log item.
     """
-    log = LogItem(s, level)
-    if self.paused:
-      self.append_truncate(self._paused_buffer, log)
-    else:
-      self.append_truncate(self.unfiltered_list, log)
-      if log.matches_log_level_filter(self.log_level_filter):
-        self.append_truncate(self.filtered_list, log)
+    if s and not s.isspace():
+      log = LogItem(s, level)
+      if self.paused:
+        self.append_truncate(self._paused_buffer, log)
+      else:
+        self.append_truncate(self.unfiltered_list, log)
+        if log.matches_log_level_filter(self.log_level_filter):
+          self.append_truncate(self.filtered_list, log)
 
   def append_truncate(self, buffer, s):
     """


### PR DESCRIPTION
This PR does the following per feedback from sprint exit on 08/21:

* adds a mouseover on log level filter to help tell people how the filtering works
* adds  a command line argument to console set initial log level filter of console
* removes lines on the tabular view of the console output
* puts newlines which exist for formatting of the log/print message as separate rows in the table
