### PR TITLE
remove silly nanosecond thing from messages that are only precise to …

### DIFF
--- a/piksi_tools/console/baseline_view.py
+++ b/piksi_tools/console/baseline_view.py
@@ -157,8 +157,6 @@ class BaselineView(HasTraits):
     dist = np.sqrt(soln.n**2 + soln.e**2 + soln.d**2)
 
     tow = soln.tow * 1e-3
-    if self.nsec is not None:
-      tow += self.nsec * 1e-9
 
     if self.week is not None:
       t = datetime.datetime(1980, 1, 6) + \

--- a/piksi_tools/console/console.py
+++ b/piksi_tools/console/console.py
@@ -241,7 +241,7 @@ class SwiftConsole(HasTraits):
       encoded = sbp_msg.payload.encode('ascii', 'ignore')
       for eachline in reversed(encoded.split('\n')):
         self.console_output.write_level(eachline,
-                                        str_to_log_level(msg.split(':')[0]))
+                                        str_to_log_level(eachline.split(':')[0]))
     except UnicodeDecodeError:
       print "Critical Error encoding the serial stream as ascii."
 

--- a/piksi_tools/console/solution_view.py
+++ b/piksi_tools/console/solution_view.py
@@ -156,8 +156,6 @@ class SolutionView(HasTraits):
       self.log_file = open(time.strftime("position_log_%Y%m%d-%H%M%S.csv"), 'w')
       self.log_file.write("time,latitude(degrees),longitude(degrees),altitude(meters),n_sats,flags\n")
     tow = soln.tow * 1e-3
-    if self.nsec is not None:
-      tow += self.nsec * 1e-9
 
     if self.week is not None:
       t = datetime.datetime(1980, 1, 6) + \
@@ -261,8 +259,6 @@ class SolutionView(HasTraits):
       self.vel_log_file.write('time,north(m/s),east(m/s),down(m/s),speed(m/s),num_sats\n')
 
     tow = vel_ned.tow * 1e-3
-    if self.nsec is not None:
-      tow += self.nsec * 1e-9
 
     if self.week is not None:
       t = datetime.datetime(1980, 1, 6) + \


### PR DESCRIPTION
…the msec.

combing two SBP messages (time and a solution) on your PC assumes a lot and makes the recorded files technically wrong compared to the SBP that they record.