### PR TITLE
make sure return code is 1 when bootload fails due to timeout

### DIFF
--- a/piksi_tools/bootload.py
+++ b/piksi_tools/bootload.py
@@ -192,7 +192,7 @@ def main():
           return
         if not (handshake_received and piksi_bootloader.handshake_received):
           print "No handshake received."
-          return 1
+          sys.exit(1) 
         print "received."
         print "Piksi Onboard Bootloader Version:", piksi_bootloader.version
         if piksi_bootloader.sbp_version > (0, 0):


### PR DESCRIPTION
We should timeout if we don't receive the handshake from the device after a reasonable amount of time.  