### PR TITLE
Change default UartA Baud text in settings

### DIFF
--- a/piksi_tools/console/settings.yaml
+++ b/piksi_tools/console/settings.yaml
@@ -568,7 +568,7 @@
   name: baudrate
   type: integer
   units: baud
-  default value: '115200'
+  default value: '57600'
   enumerated possible values:
   Description: The baudrate for the UART
   Notes: The radio baudrate may be constrained by the particular RF equipment used


### PR DESCRIPTION
Change the text for the default baud in settings.yaml . This is a continuation from this pull request to change the default baud on 3DR radios. 

https://github.com/swift-nav/piksi_firmware/pull/564