### PR TITLE
Console updates for v0.21 firmware

### DIFF
--- a/piksi_tools/console/baseline_view.py
+++ b/piksi_tools/console/baseline_view.py
@@ -126,10 +126,6 @@ class BaselineView(HasTraits):
     self.plot_data.set_data('cur_float_e', [])
     self.plot_data.set_data('cur_float_d', [])
 
-  def _baseline_callback_ecef(self, data, **metadata):
-    #Don't do anything for ECEF currently
-    return
-
   def iar_state_callback(self, sbp_msg, **metadata):
     self.num_hyps = sbp_msg.num_hyps
 
@@ -327,7 +323,6 @@ class BaselineView(HasTraits):
 
     self.link = link
     self.link.add_callback(self._baseline_callback_ned, SBP_MSG_BASELINE_NED)
-    self.link.add_callback(self._baseline_callback_ecef, SBP_MSG_BASELINE_ECEF)
     self.link.add_callback(self.iar_state_callback, SBP_MSG_IAR_STATE)
     self.link.add_callback(self.gps_time_callback, SBP_MSG_GPS_TIME)
 

--- a/piksi_tools/console/settings.yaml
+++ b/piksi_tools/console/settings.yaml
@@ -403,6 +403,17 @@
   Description: Receiver Autonomous Integrity Monitoring
   Notes: If True, RAIM checks will not be performed.
 
+- group: solution
+  name: send_heading
+  type: boolean
+  expert: true
+  units:
+  default value: False
+  enumerated possible values: True,False
+  Description: Enables SBP heading output.  Heading is caculated from base station to 
+    rover and represents the inverse tangent of the north and east components of the baseline.
+  Notes: No smoothing or additional processing is provided to improve heading output.
+
 - group: system_info
   name: serial_number
   type: integer

--- a/piksi_tools/console/system_monitor_view.py
+++ b/piksi_tools/console/system_monitor_view.py
@@ -141,8 +141,9 @@ class SystemMonitorView(HasTraits):
         self.threads, key=lambda x: x[1].cpu, reverse=True)]
 
   def heartbeat_callback(self, sbp_msg, **metadata):
-    self.update_threads()
-    self.threads = []
+    if self.threads != []: 
+      self.update_threads()
+      self.threads = []
 
   def thread_state_callback(self, sbp_msg, **metadata):
     if sbp_msg.name == '':

--- a/piksi_tools/console/update_view.py
+++ b/piksi_tools/console/update_view.py
@@ -236,7 +236,7 @@ class UpdateView(HasTraits):
         'stream',
         style='custom',
         editor=InstanceEditor(),
-        show_label=False, 
+        show_label=False,
       ),
     )
   )
@@ -260,6 +260,7 @@ class UpdateView(HasTraits):
 
     }
     self.update_dl = None
+    self.erase_en = True
     self.stm_fw = IntelHexFileDialog('STM')
     self.stm_fw.on_trait_change(self._manage_enables, 'status')
     self.nap_fw = IntelHexFileDialog('M25')
@@ -274,8 +275,10 @@ class UpdateView(HasTraits):
       self.update_nap_en = False
       self.update_en = False
       self.download_fw_en = False
+      self.erase_en = False
     else:
       self.download_fw_en = True
+      self.erase_en = True
       if self.stm_fw.ihx is not None:
         self.update_stm_en = True
       else:
@@ -288,10 +291,6 @@ class UpdateView(HasTraits):
         self.update_en = False
       if self.nap_fw.ihx is not None and self.stm_fw.ihx is not None:
         self.update_en = True
-    if self.updating == True:
-      self.erase_en = False
-    else:
-      self.erase_en = True
 
   def _updating_changed(self):
     """ Handles self.updating trait being changed. """
@@ -586,7 +585,7 @@ class UpdateView(HasTraits):
     self._write("")
     progress_dialog.close()
 
-  def manage_nap_firmware_update(self):
+  def manage_nap_firmware_update(self, check_version=False):
     # Flash NAP if out of date.
     try:
       local_nap_version = parse_version(
@@ -595,7 +594,7 @@ class UpdateView(HasTraits):
       nap_out_of_date = local_nap_version != remote_nap_version
     except KeyError:
       nap_out_of_date = True
-    if nap_out_of_date:
+    if nap_out_of_date or check_version==False:
       text = "Updating NAP"
       self._write(text)
       self.create_flash("M25")
@@ -631,7 +630,7 @@ class UpdateView(HasTraits):
       update_nap = self.manage_nap_firmware_update()
     else:
       self.manage_stm_firmware_update()
-      update_nap = self.manage_nap_firmware_update()
+      update_nap = self.manage_nap_firmware_update(check_version=True)
 
     # Must tell Piksi to jump to application after updating firmware.
     if device == "STM" or update_nap:


### PR DESCRIPTION
*decouple heartbeat and threadstate message rate 
*allow a user to flash whatever nap he wants if he presses the flash nap only button
*remove one unnecessary callback in solution view