### PR TITLE
Packaging fixes for console and HOWTO documentation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,11 @@ os:
 
 before_install:
   - make deps
+
 script:
   - tox
   - sudo python setup.py install
+  - make build_console
 
 deploy:
   provider: pypi

--- a/HOWTO.md
+++ b/HOWTO.md
@@ -1,0 +1,61 @@
+piksi_tools Development Procedures
+==================================
+
+This document summarizes some practices around contributions to Piksi
+tools. This repository includes the Piksi console, bootloader, and a
+smattering of other tools. Of these, we typically do binary releases
+of the console. These instructions don't come with a warranty yet, so
+please feel free to update it to mirror reality.
+
+# Build, Test, and Release New Versions of the Console
+
+We build and distribute binary releases of the console for OS X and
+Windows. pyinstaller does not cross-compile binaries, so you'll have
+to build the binary on the target system. The steps are roughly:
+
+```shell
+# Check out the repository and the current release tag
+git clone https://github.com/swift-nav/piksi_tools.git
+git checkout <release-tag-name>
+
+# Install the dependencies
+make deps
+
+# Run the console to re-generate the RELEASE-VERSION file
+PYTHONPATH=. piksi_tools/console/console.py
+
+# Build the console binary and installer
+make build_console
+```
+
+The console installer (`.dmg` or `.exe`) should now be in `dist/`.
+
+To test the console installer, install it from the generated installer
+and test in OSX and Windows:
+
+OSX:
+- Do all the tabs appear to be working properly?
+- Can you update a Piksi with the new console which has the previously
+  released STM Firmware / NAP HDL on it?
+
+Windows:
+- Do all the tabs appear to be working properly?
+- Can you update a Piksi with the new console which has the previously
+  released STM Firmware / NAP HDL on it?
+- Test on the following versions of (32-bit and 64-bit) Windows
+  (Windows XP, Windows 7,Windows 8, Windows 10).
+
+Linux (no generated binary):
+- Test the install of and function of the console on a fresh linux VM
+  snapshot.
+
+Upload the console binaries from `dist/` to the
+[AWS S3 bucket](http://downloads.swiftnav.com/piksi_console/) and
+update the console version number in the `index.json` there.
+
+# Contributions
+
+This library is developed internally by Swift Navigation. We welcome
+Github issues and pull requests, as well as discussions of potential
+problems and enhancement suggestions on the
+[forum](https://groups.google.com/forum/#!forum/swiftnav-discuss).

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,17 @@ SWIFTNAV_ROOT := $(shell pwd)
 MAKEFLAGS += SWIFTNAV_ROOT=$(SWIFTNAV_ROOT)
 export PYTHONPATH := .
 
-.PHONY: help deps
+ifneq (,$(findstring /cygdrive/,$(PATH)))
+    UNAME := Windows
+else
+ifneq (,$(findstring WINDOWS,$(PATH)))
+    UNAME := Windows
+else
+    UNAME := $(shell uname -s)
+endif
+endif
+
+.PHONY: help deps serial_deps build_console build_console_posix build_console_Darwin build_console_Linux build_console_Windows
 
 help:
 	@echo
@@ -15,8 +25,10 @@ help:
 	@echo "(Please read before using!)"
 	@echo
 	@echo "Please use \`make <target>' where <target> is one of"
-	@echo "  help      to display this help message"
-	@echo "  deps      to install dependencies"
+	@echo "  help           to display this help message"
+	@echo "  deps           to install all dependencies (includes UI deps)"
+	@echo "  serial_deps    to install serial dependencies (no UI deps)"
+	@echo "  build_console  to build the console binary and installer"
 	@echo
 
 all: deps
@@ -26,3 +38,20 @@ deps:
 
 serial_deps:
 	sudo pip install -r requirements.txt
+
+build_console:
+	make build_console_$(UNAME)
+
+build_console_posix:
+	cd $(SWIFTNAV_ROOT)/piksi_tools/console/pyinstaller; \
+	sudo make clean && sudo make; \
+	cd $(SWIFTNAV_ROOT);
+	@echo
+	@echo "Finished! Please check $(SWIFTNAV_ROOT)/piksi_tools/console/pyinstaller."
+
+build_console_Darwin: build_console_posix
+
+build_console_Linux: build_console_posix
+
+build_console_Windows:
+	@echo "Alas! Makefile setup for console building not supported on Windoze!"

--- a/piksi_tools/acq_results.py
+++ b/piksi_tools/acq_results.py
@@ -39,7 +39,7 @@ class AcqResults():
   def __init__(self, link):
     self.acqs = []
     self.link = link
-    self.link.add_callback(self._receive_acq_result, [SBP_MSG_ACQ_RESULT, SBP_MSG_ACQ_RESULT_DEP_A])
+    self.link.add_callback(self._receive_acq_result, SBP_MSG_ACQ_RESULT)
     self.max_corr = 0
 
   def __str__(self):
@@ -74,7 +74,7 @@ class AcqResults():
   def _receive_acq_result(self, sbp_msg, **metadata):
     while N_RECORD > 0 and len(self.acqs) >= N_RECORD:
       self.acqs.pop(0)
-    self.acqs.append(MsgAcqResult(sbp_msg) if sbp_msg.msg_type is SBP_MSG_ACQ_RESULT else MsgAcqResultDepA(sbp_msg))
+    self.acqs.append(MsgAcqResult(sbp_msg))
 
   def _receive_acq_result_dep_a(self, sbp_msg, **metadata):
     while N_RECORD > 0 and len(self.acqs) >= N_RECORD:

--- a/piksi_tools/console/baseline_view.py
+++ b/piksi_tools/console/baseline_view.py
@@ -16,7 +16,7 @@ from chaco.tools.api import ZoomTool, PanTool
 from enable.api import ComponentEditor
 from enable.savage.trait_defs.ui.svg_button import SVGButton
 from pyface.api import GUI
-from utils import plot_square_axes
+from piksi_tools.console.utils import plot_square_axes
 
 import math
 import os

--- a/piksi_tools/console/console.py
+++ b/piksi_tools/console/console.py
@@ -15,14 +15,15 @@ import sbp.client as sbpc
 import signal
 import sys
 
-from piksi_tools.version import VERSION as CONSOLE_VERSION
+from piksi_tools.console.deprecated import DeprecatedMessageHandler
 from piksi_tools.serial_link import swriter, get_uuid, DEFAULT_BASE
+from piksi_tools.version import VERSION as CONSOLE_VERSION
+from sbp.client.drivers.network_drivers import HTTPDriver
+from sbp.client.drivers.pyftdi_driver import PyFTDIDriver
+from sbp.client.drivers.pyserial_driver import PySerialDriver
+from sbp.ext_events import *
 from sbp.logging import *
 from sbp.piksi import SBP_MSG_RESET, MsgReset
-from sbp.client.drivers.network_drivers import HTTPDriver
-from sbp.client.drivers.pyserial_driver import PySerialDriver
-from sbp.client.drivers.pyftdi_driver import PyFTDIDriver
-from sbp.ext_events import *
 
 # Shut chaco up for now
 import warnings
@@ -97,7 +98,7 @@ else:
 # Logging
 import logging
 logging.basicConfig()
-from output_list import OutputList, LogItem, str_to_log_level, SYSLOG_LEVELS, DEFAULT_LOG_LEVEL_FILTER
+from piksi_tools.console.output_list import OutputList, LogItem, str_to_log_level, SYSLOG_LEVELS, DEFAULT_LOG_LEVEL_FILTER
 from traits.api import Str, Instance, Dict, HasTraits, Int, Button, List, Enum
 from traitsui.api import Item, Label, View, HGroup, VGroup, VSplit, HSplit, Tabbed, \
                          InstanceEditor, EnumEditor, ShellEditor, Handler, Spring, \
@@ -139,15 +140,15 @@ else:
     basedir = os.path.dirname(__file__)
 icon = ImageResource('icon', search_path=['images', os.path.join(basedir, 'images')])
 
-from output_stream import OutputStream
-from tracking_view import TrackingView
-from solution_view import SolutionView
-from baseline_view import BaselineView
-from observation_view import ObservationView
-from sbp_relay_view import SbpRelayView
-from system_monitor_view import SystemMonitorView
-from settings_view import SettingsView
-from update_view import UpdateView
+from piksi_tools.console.output_stream import OutputStream
+from piksi_tools.console.tracking_view import TrackingView
+from piksi_tools.console.solution_view import SolutionView
+from piksi_tools.console.baseline_view import BaselineView
+from piksi_tools.console.observation_view import ObservationView
+from piksi_tools.console.sbp_relay_view import SbpRelayView
+from piksi_tools.console.system_monitor_view import SystemMonitorView
+from piksi_tools.console.settings_view import SettingsView
+from piksi_tools.console.update_view import UpdateView
 from enable.savage.trait_defs.ui.svg_button import SVGButton
 
 CONSOLE_TITLE = 'Piksi Console, Version: ' + CONSOLE_VERSION
@@ -160,6 +161,7 @@ class ConsoleHandler(Handler):
   This Handler is used by Traits UI to manage making changes to the GUI in
   response to changes in the underlying class/data.
   """
+
   def object_device_serial_changed(self, info):
     """
     Update the window title with the device serial number.
@@ -314,6 +316,7 @@ class SwiftConsole(HasTraits):
       self.link.add_callback(self.print_message_callback, SBP_MSG_PRINT_DEP)
       self.link.add_callback(self.log_message_callback, SBP_MSG_LOG)
       self.link.add_callback(self.ext_event_callback, SBP_MSG_EXT_EVENT)
+      self.dep_handler = DeprecatedMessageHandler(link)
       settings_read_finished_functions = []
       self.tracking_view = TrackingView(self.link)
       self.solution_view = SolutionView(self.link)

--- a/piksi_tools/console/deprecated.py
+++ b/piksi_tools/console/deprecated.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+# Copyright (C) 2015 Swift Navigation Inc.
+# Contact: Bhaskar Mookerji <mookerji@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+"""Deprecated SBP message types and utilities.
+
+If you having sbp problems I feel bad for you son
+I got 99 callbacks but your type ain't one
+
+"""
+
+from sbp.acquisition import SBP_MSG_ACQ_RESULT_DEP_A
+from sbp.observation import SBP_MSG_EPHEMERIS_DEP_A, SBP_MSG_EPHEMERIS_DEP_B, SBP_MSG_OBS_DEP_A
+from sbp.tracking import SBP_MSG_TRACKING_STATE_DEP_A
+
+DEPRECATED_SBP_MESSAGES = [SBP_MSG_ACQ_RESULT_DEP_A,
+                           SBP_MSG_EPHEMERIS_DEP_A,
+                           SBP_MSG_EPHEMERIS_DEP_B,
+                           SBP_MSG_OBS_DEP_A,
+                           SBP_MSG_TRACKING_STATE_DEP_A]
+
+class DeprecatedMessageHandler(object):
+  """Callback prompt for issuing a feature deprecation prompt in the
+  console.
+
+  Parameters
+  ----------
+  link : sbp.client.handler.Handler
+    Link for SBP transfer to/from Piksi.
+  dep_whitelist : [int]
+    List of SBP messages to warn on (defaults to DEPRECATED_SBP_MESSAGES)
+
+  """
+
+  def __init__(self, link, dep_whitelist=DEPRECATED_SBP_MESSAGES):
+    self._user_warned = False
+    self._link = link
+    self._dep_whitelist = dep_whitelist
+    self._link.add_callback(self._dep_msg_handler, dep_whitelist)
+
+  def _dep_msg_handler(self, sbp_msg, **metadata):
+    if not self._user_warned:
+      msg = ("Warning! Piksi is outputing deprecated observations \n"
+             "which cannot be displayed with the current version of the console.\n\n"
+             "We highly recommend upgrading your firmware to\n"
+             "most recent version available at http://downloads.swiftnav.com.\n\n")
+      self._prompt_dep_warning(msg)
+      self._user_warned = True
+      self._link.remove_callback(self._dep_msg_handler, self._dep_whitelist)
+
+  def _prompt_dep_warning(self, text):
+    """Nonblocking prompt for a deprecation warning.
+
+    Parameters
+    ----------
+    txt : str
+      Helpful error message for the user
+
+    """
+    from piksi_tools.console.callback_prompt import CallbackPrompt, close_button
+    prompt = CallbackPrompt(title="Deprecation Warning", actions=[close_button])
+    prompt.text = text
+    prompt.run(block=False)

--- a/piksi_tools/console/settings_view.py
+++ b/piksi_tools/console/settings_view.py
@@ -30,7 +30,7 @@ import numpy as np
 import datetime
 
 from piksi_tools.fileio import FileIO
-import callback_prompt as prompt
+import piksi_tools.console.callback_prompt as prompt
 
 from sbp.piksi      import *
 from sbp.settings   import *

--- a/piksi_tools/console/solution_view.py
+++ b/piksi_tools/console/solution_view.py
@@ -17,7 +17,7 @@ from chaco.tools.api import ZoomTool, PanTool
 from enable.api import ComponentEditor
 from enable.savage.trait_defs.ui.svg_button import SVGButton
 from pyface.api import GUI
-from utils import plot_square_axes
+from piksi_tools.console.utils import plot_square_axes
 
 import math
 import os

--- a/piksi_tools/console/update_view.py
+++ b/piksi_tools/console/update_view.py
@@ -26,7 +26,7 @@ from pyface.api import GUI, FileDialog, OK, ProgressDialog
 from piksi_tools.version import VERSION as CONSOLE_VERSION
 from piksi_tools import bootload
 from piksi_tools import flash
-import callback_prompt as prompt
+import piksi_tools.console.callback_prompt as prompt
 from update_downloader import UpdateDownloader
 from output_stream import OutputStream
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,7 @@ pygments==2.0.2
 requests
 six
 construct
-sbp==0.51.3
+sbp==0.51.5
+#pyinstaller requirements
+pyinstaller
+cryptography


### PR DESCRIPTION
As part of getting the OS X console build working with OS X, I made
some fixes that seemed required to get things to build.

0. Absolute package imports.
1. Removing deprecated message callbacks.
2. HOWTO for releases and Makefile update
3. Get travis to check console build

/cc @denniszollo @fnoble @cbeighley @JoshuaGross