### PR TITLE
Constrain console python dependencies.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,11 +15,12 @@ pyserial==2.7
 pylibftdi==0.14.2
 pyparsing==1.5.7
 pygments==2.0.2
-requests
-kiwisolver
-six
-construct
-sbp==0.51.5
-#pyinstaller requirements
-pyinstaller
-cryptography
+requests>=2.8.1
+# Required for windows pyinstaller
+kiwisolver>=0.1.3
+six>=1.10.0
+construct>=2.5.2
+sbp==0.51.7
+# pyinstaller requirements
+pyinstaller>=3.0
+cryptography>=1.1.1


### PR DESCRIPTION
Hopefully resolves Linux install issue where a existing, outdated
version of the requests dependency prevents the console from
starting. Minimum dependencies here are taken from OS X 10.9, Python
2.7.

/cc @denniszollo