### PR TITLE
Console updates for HTTP POST.

### DIFF
--- a/piksi_tools/console/sbp_relay_view.py
+++ b/piksi_tools/console/sbp_relay_view.py
@@ -9,21 +9,32 @@
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 
+from callback_prompt import CallbackPrompt, close_button
+from concurrent.futures import ThreadPoolExecutor
+from piksi_tools.serial_link import DEFAULT_WHITELIST, swriter, get_uuid, \
+  DEFAULT_BASE, CHANNEL_UUID
+from sbp.client.drivers.network_drivers import HTTPDriver
+from sbp.client.forwarder import Forwarder
+from sbp.client.framer import Framer
+from sbp.client.handler import Handler
+from sbp.client.loggers.udp_logger import UdpLogger
+from sbp.observation import SBP_MSG_OBS, SBP_MSG_BASE_POS
 from traits.api import HasTraits, String, Button, Instance, Int, Bool, \
                        on_trait_change, Enum
-from traitsui.api import View, Item, VGroup, UItem, HGroup, TextEditor, spring
-from sbp.observation import SBP_MSG_OBS, SBP_MSG_BASE_POS
-from sbp.client.loggers.udp_logger import UdpLogger
+from traitsui.api import View, Item, VGroup, UItem, HGroup, TextEditor, \
+  spring
+import sys
+import time
 
 DEFAULT_UDP_ADDRESS = "127.0.0.1"
 DEFAULT_UDP_PORT = 13320
-
-OBS_MSGS = [SBP_MSG_OBS, SBP_MSG_BASE_POS,]
+OBS_MSGS = DEFAULT_WHITELIST
 
 class MyTextEditor(TextEditor):
   """
   Override of TextEditor Class for a multi-lin read only
   """
+
   def init(self, parent):
     parent.read_only = True
     parent.multi_line = True
@@ -39,41 +50,67 @@ class SbpRelayView(HasTraits):
   msg_enum = Enum('Observations', 'All')
   ip_ad = String(DEFAULT_UDP_ADDRESS)
   port = Int(DEFAULT_UDP_PORT)
-  information = String('This tab is used to broadcast SBP information received by'
+  information = String('UDP Streaming\n\nBroadcast SBP information received by'
     ' the console to other machines or processes over UDP. With the \'Observations\''
     ' radio button selected, the console will broadcast the necessary information'
     ' for a rover Piksi to acheive an RTK solution.'
-    '\n\nThis tab can be used to stream observations to a remote Piksi through'
+    '\n\nThis can be used to stream observations to a remote Piksi through'
     ' aircraft telemetry via ground control software such as MAVProxy or'
     ' Mission Planner.')
-
+  http_information = String('Skylark - Experimental Piksi Networking\n\n'
+                            'Skylark is an Internet service for connecting Piksi receivers without the use of a radio. To receive GPS observations from the closest nearby Piksi base station (within 5km), click Connect to Skylark.\n\nTo hide your observations (and position) from other nearby Piksi receivers, select the checkbox Hide Observations From Other Receivers.\n\n')
   start = Button(label='Start', toggle=True, width=32)
-
   stop = Button(label='Stop', toggle=True, width=32)
+  connected_rover = Bool(False)
+  connect_rover = Button(label='Connect to Skylark', toggle=True, width=32)
+  disconnect_rover = Button(label='Disconnect from Skylark', toggle=True, width=32)
+  hide_observations_from_other_receivers = Bool(False)
+  toggle=True
   view = View(
-          HGroup(
-            VGroup(
-              Item('running', show_label=True, style='readonly', visible_when='running'),
-              Item('msg_enum', label="Messages to broadcast", style='custom',
-                   enabled_when='not running'),
-              Item('ip_ad', label='IP Address', enabled_when='not running'),
-              Item('port', label="Port", enabled_when='not running'),
-              HGroup(
-                spring,
-                UItem('start', enabled_when='not running', show_label=False),
-                UItem('stop', enabled_when='running', show_label=False),
-                spring
-                )
-              ),
-              VGroup(
-                Item('information', label="Notes", height=10,
-                editor=MyTextEditor(TextEditor(multi_line=True)), style='readonly',
-                show_label=False, resizable=True, padding=15),
-                spring,
-              ),
-            )
-          )
-  def __init__(self, link):
+           VGroup(
+             spring,
+             HGroup(
+               VGroup(
+                 Item('running', show_label=True, style='readonly', visible_when='running'),
+                 Item('msg_enum', label="Messages to broadcast",
+                      style='custom', enabled_when='not running'),
+                 Item('ip_ad', label='IP Address', enabled_when='not running'),
+                 Item('port', label="Port", enabled_when='not running'),
+                 HGroup(
+                   spring,
+                   UItem('start', enabled_when='not running', show_label=False),
+                   UItem('stop', enabled_when='running', show_label=False),
+                   spring)),
+               VGroup(
+                 Item('information', label="Notes", height=10,
+                      editor=MyTextEditor(TextEditor(multi_line=True)), style='readonly',
+                      show_label=False, resizable=True, padding=15),
+                 spring,
+               ),
+             ),
+             spring,
+             HGroup(
+               VGroup(
+                 HGroup(
+                   spring,
+                   UItem('connect_rover', enabled_when='not connected_rover', show_label=False),
+                   UItem('disconnect_rover', enabled_when='connected_rover', show_label=False),
+                   spring),
+                 HGroup(spring,
+                        Item('hide_observations_from_other_receivers'),
+                        spring),),
+               VGroup(
+                 Item('http_information', label="Notes", height=10,
+                      editor=MyTextEditor(TextEditor(multi_line=True)), style='readonly',
+                      show_label=False, resizable=True, padding=15),
+                 spring,
+               ),
+             ),
+             spring
+           )
+  )
+
+  def __init__(self, link, device_uid=None, base=DEFAULT_BASE, whitelist=None):
     """
     Traits tab with UI for UDP broadcast of SBP.
 
@@ -81,17 +118,32 @@ class SbpRelayView(HasTraits):
     ----------
     link : sbp.client.handler.Handler
       Link for SBP transfer to/from Piksi.
+    device_uid : str
+      Piksi Device UUID (defaults to None)
+    base : str
+      HTTP endpoint
+    whitelist : [int] | None
+      Piksi Device UUID (defaults to None)
+
     """
+    self.link = link
+    self.http = HTTPDriver(None, base)
+    self.net_link = None
+    self.fwd = None
     self.func = None
+    # Whitelist used for UDP broadcast view
     self.msgs = OBS_MSGS
     # register a callback when the msg_enum trait changes
     self.on_trait_change(self.update_msgs, 'msg_enum')
-    self.link = link
+    # Whitelist used for Skylark broadcasting
+    self.whitelist = whitelist
+    self.device_uid = None
     self.python_console_cmds = {'update': self}
 
   def update_msgs(self):
-    """
-    Updates the instance variable msgs which store the msgs that we will send over UDP
+    """Updates the instance variable msgs which store the msgs that we
+    will send over UDP.
+
     """
     if self.msg_enum == 'Observations':
       self.msgs = OBS_MSGS
@@ -100,10 +152,134 @@ class SbpRelayView(HasTraits):
     else:
       raise NotImplementedError
 
-  def _start_fired(self):
+  def set_route(self, serial_id, channel=CHANNEL_UUID):
+    """Sets serial_id hash for HTTP headers.
+
+    Parameters
+    ----------
+    serial_id : int
+      Piksi device ID
+    channel : str
+      UUID namespace for device UUID
+
     """
-    Handle start udp broadcast button. Registers callbacks on self.link for each of the self.msgs
-    If self.msgs is None, it registers one generic callback for all messages
+    device_uid = str(get_uuid(channel, serial_id))
+    self.device_uid = device_uid
+    if self.http:
+      self.http.device_uid = device_uid
+
+  def _prompt_networking_error(self, text):
+    """Nonblocking prompt for a networking error.
+
+    Parameters
+    ----------
+    text : str
+      Helpful error message for the user
+
+    """
+    prompt = CallbackPrompt(title="Networking Error", actions=[close_button])
+    prompt.text = text
+    prompt.run(block=False)
+
+  def _prompt_setting_error(self, text):
+    """Nonblocking prompt for a device setting error.
+
+    Parameters
+    ----------
+    text : str
+      Helpful error message for the user
+
+    """
+    prompt = CallbackPrompt(title="Setting Error", actions=[close_button])
+    prompt.text = text
+    prompt.run(block=False)
+
+  def _retry_read(self):
+    """Retry read connections. Intended to be called by
+    _connect_rover_fired.
+
+    """
+    i = 0
+    repeats = 5
+    while self.http and not self.http.connect_read():
+      print "Attempting to read observation from Skylark..."
+      time.sleep(0.1)
+      i += 1
+      if i >= repeats:
+        self._prompt_networking_error("\nUnable to receive observations!")
+        self.http.read_close()
+        return
+    print "Connected as a rover!"
+    with Handler(Framer(self.http.read, self.http.write)) as net_link:
+      self.net_link = net_link
+      self.fwd = Forwarder(net_link, swriter(self.link))
+      self.fwd.start()
+      while True:
+        time.sleep(1)
+        if not net_link.is_alive():
+          sys.stderr.write("Network observation stream disconnected!")
+          break
+
+  def _connect_rover_fired(self):
+    """Handle callback for HTTP rover connections.
+
+    """
+    if not self.device_uid:
+      msg = "\nDevice ID not found!\n\nConnection requires a valid Piksi device ID."
+      self._prompt_setting_error(msg)
+      return
+    if not self.http:
+      self._prompt_networking_error("\nNetworking disabled!")
+      return
+    try:
+      _passive = self.hide_observations_from_other_receivers
+      if not self.http.connect_write(self.link, self.whitelist, passive=_passive):
+        msg = ("\nUnable to connect to Skylark!\n\n"
+               "Please check that:\n"
+               " - you have a network connection\n"
+               " - your Piksi has a single-point position\n"
+               " - a Skylark-connected Piksi receiver \n   is nearby (within 10km)")
+        self._prompt_networking_error(msg)
+        self.http.close()
+        self.connected_rover = False
+        return
+      self.connected_rover = True
+      if not _passive:
+        print "Connected as a base station!"
+      executor = ThreadPoolExecutor(max_workers=2)
+      executor.submit(self._retry_read)
+    except:
+      self.connected_rover = False
+      import traceback
+      print traceback.format_exc()
+
+  def _disconnect_rover_fired(self):
+    """Handle callback for HTTP rover disconnects.
+
+    """
+    if not self.device_uid:
+      msg = "\nDevice ID not found!\n\nConnection requires a valid Piksi device ID."
+      self._prompt_setting_error(msg)
+      return
+    if not self.http:
+      self._prompt_networking_error("\nNetworking disabled!")
+      return
+    try:
+      if self.connected_rover:
+        self.http.close()
+        self.connected_rover = False
+        if self.fwd and self.net_link:
+          self.net_link.stop()
+    except:
+      self.connected_rover = False
+      import traceback
+      print traceback.format_exc()
+
+  def _start_fired(self):
+    """Handle start udp broadcast button. Registers callbacks on
+    self.link for each of the self.msgs If self.msgs is None, it
+    registers one generic callback for all messages.
+
     """
     self.running = True
     try:
@@ -114,9 +290,10 @@ class SbpRelayView(HasTraits):
       print traceback.format_exc()
 
   def _stop_fired(self):
-    """
-    Handle the stop udp broadcast button. It uses the self.funcs and self.msgs to remove
-    the callbacks that were registered when the start button was pressed.
+    """Handle the stop udp broadcast button. It uses the self.funcs and
+    self.msgs to remove the callbacks that were registered when the
+    start button was pressed.
+
     """
     try:
       self.link.remove_callback(self.func, self.msgs)

--- a/piksi_tools/serial_link.py
+++ b/piksi_tools/serial_link.py
@@ -22,6 +22,10 @@ import warnings
 
 from sbp.bootload                       import *
 from sbp.logging                        import *
+from sbp.navigation import SBP_MSG_POS_ECEF, SBP_MSG_POS_LLH, SBP_MSG_BASELINE_ECEF, \
+  SBP_MSG_BASELINE_NED, SBP_MSG_GPS_TIME
+from sbp.observation import SBP_MSG_OBS, SBP_MSG_EPHEMERIS
+from sbp.user import SBP_MSG_USER_DATA
 from sbp.piksi                          import MsgReset
 from sbp.system                         import SBP_MSG_HEARTBEAT
 from sbp.client.drivers.network_drivers import HTTPDriver
@@ -30,6 +34,7 @@ from sbp.client.drivers.pyftdi_driver   import PyFTDIDriver
 from sbp.client.loggers.json_logger     import JSONLogger
 from sbp.client.loggers.null_logger     import NullLogger
 from sbp.client                         import Handler, Framer, Forwarder
+
 
 LOG_FILENAME = time.strftime("serial-link-%Y%m%d-%H%M%S.log.json")
 
@@ -258,6 +263,16 @@ def run(args, link):
     # SystemExit exception.
     sys.exit(1)
 
+# The default whitelist of messages for the Piksi to publish
+DEFAULT_WHITELIST = [SBP_MSG_HEARTBEAT,
+                     SBP_MSG_OBS,
+                     SBP_MSG_EPHEMERIS,
+                     SBP_MSG_POS_ECEF,
+                     SBP_MSG_POS_LLH,
+                     SBP_MSG_GPS_TIME,
+                     SBP_MSG_USER_DATA,
+                     SBP_MSG_TWEET]
+
 def main(args):
   """
   Get configuration, get driver, get logger, and build handler and start it.
@@ -290,9 +305,9 @@ def main(args):
           Forwarder(link, append_logger).start()
           if use_broker and base and serial_id:
             device_id = get_uuid(channel, serial_id)
-            with HTTPDriver(str(device_id), base) as http_driver:
-              with Handler(Framer(http_driver.read, None, args.verbose)) as slink:
-                slink.add_callback(swriter(link))
+            with HTTPDriver(str(device_id), base) as http:
+              with Handler(Framer(http.read, http.write, args.verbose)) as slink:
+                Forwarder(slink, swriter(link)).start()
                 run(args, link)
           run(args, link)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ requests>=2.8.1
 kiwisolver>=0.1.3
 six>=1.10.0
 construct>=2.5.2
-sbp==0.51.7
+sbp==0.51.10
 # pyinstaller requirements
 pyinstaller>=3.0
 cryptography>=1.1.1


### PR DESCRIPTION
0. Updates the HTTP file-like driver to POST messages to Skylark as
well. Doesn't block the UI thread.
1. New Skylark UI view using settings device_id.
2. Removes command line configuration for Skylark usage in console,
since this is now embedded in the console. Moves all this handling to
the networking view, since this is where it obviously belongs.

/cc @mfine @denniszollo @fnoble @JoshuaGross