### PR TITLE
Rtk position tab annotated

### DIFF
--- a/piksi_tools/console/sbp_relay_view.py
+++ b/piksi_tools/console/sbp_relay_view.py
@@ -13,6 +13,7 @@ from callback_prompt import CallbackPrompt, close_button
 from concurrent.futures import ThreadPoolExecutor
 from piksi_tools.serial_link import DEFAULT_WHITELIST, swriter, get_uuid, \
   DEFAULT_BASE, CHANNEL_UUID
+from piksi_tools.console.utils import MultilineTextEditor
 from sbp.client.drivers.network_drivers import HTTPDriver
 from sbp.client.forwarder import Forwarder
 from sbp.client.framer import Framer
@@ -23,21 +24,13 @@ from traits.api import HasTraits, String, Button, Instance, Int, Bool, \
                        on_trait_change, Enum
 from traitsui.api import View, Item, VGroup, UItem, HGroup, TextEditor, \
   spring
+
 import sys
 import time
 
 DEFAULT_UDP_ADDRESS = "127.0.0.1"
 DEFAULT_UDP_PORT = 13320
 OBS_MSGS = DEFAULT_WHITELIST
-
-class MyTextEditor(TextEditor):
-  """
-  Override of TextEditor Class for a multi-lin read only
-  """
-
-  def init(self, parent):
-    parent.read_only = True
-    parent.multi_line = True
 
 class SbpRelayView(HasTraits):
   """
@@ -83,7 +76,7 @@ class SbpRelayView(HasTraits):
                    spring)),
                VGroup(
                  Item('information', label="Notes", height=10,
-                      editor=MyTextEditor(TextEditor(multi_line=True)), style='readonly',
+                      editor=MultilineTextEditor(TextEditor(multi_line=True)), style='readonly',
                       show_label=False, resizable=True, padding=15),
                  spring,
                ),
@@ -101,7 +94,7 @@ class SbpRelayView(HasTraits):
                         spring),),
                VGroup(
                  Item('http_information', label="Notes", height=10,
-                      editor=MyTextEditor(TextEditor(multi_line=True)), style='readonly',
+                      editor=MultilineTextEditor(TextEditor(multi_line=True)), style='readonly',
                       show_label=False, resizable=True, padding=15),
                  spring,
                ),

--- a/piksi_tools/console/settings_view.py
+++ b/piksi_tools/console/settings_view.py
@@ -31,7 +31,7 @@ import datetime
 
 from piksi_tools.fileio import FileIO
 import piksi_tools.console.callback_prompt as prompt
-from piksi_tools.console.utils import determine_path
+from piksi_tools.console.utils import determine_path, MultilineTextEditor
 
 from sbp.piksi      import *
 from sbp.settings   import *
@@ -55,11 +55,6 @@ class SettingBase(HasTraits):
   def __str__(self):
     return self.value
 
-class MyTextEditor(TextEditor):
-  def init(self,parent):
-    parent.read_only = True
-    parent.multi_line = True
-
 class Setting(SettingBase):
   full_name = Str()
   section = Str()
@@ -72,7 +67,7 @@ class Setting(SettingBase):
       Item('units', style='readonly'),
       Item('default_value', style='readonly'),
       UItem('notes', label="Notes", height=-1,
-            editor=MyTextEditor(TextEditor(multi_line=True)), style='readonly',
+            editor=MultilineTextEditor(TextEditor(multi_line=True)), style='readonly',
             show_label=True, resizable=True),
       show_border=True,
       label='Setting',
@@ -111,7 +106,7 @@ class EnumSetting(Setting):
       Item('description', style='readonly'),
       Item('default_value', style='readonly'),
             UItem('notes', label="Notes", height=-1,
-            editor=MyTextEditor(TextEditor(multi_line=True)), style='readonly',
+            editor=MultilineTextEditor(TextEditor(multi_line=True)), style='readonly',
             show_label=True, resizable=True),
       show_border=True,
       label='Setting',

--- a/piksi_tools/console/solution_view.py
+++ b/piksi_tools/console/solution_view.py
@@ -9,15 +9,15 @@
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 
-from traits.api import Instance, Dict, HasTraits, Array, Float, on_trait_change, List, Int, Button, Bool
-from traitsui.api import Item, View, HGroup, VGroup, ArrayEditor, HSplit, TabularEditor, UItem, Tabbed
+from traits.api import Instance, Dict, HasTraits, Array, Float, on_trait_change, List, Int, Button, Bool, Str
+from traitsui.api import Item, View, HGroup, VGroup, ArrayEditor, HSplit, TextEditor, TabularEditor, UItem, Tabbed
 from traitsui.tabular_adapter import TabularAdapter
 from chaco.api import ArrayPlotData, Plot
 from chaco.tools.api import ZoomTool, PanTool
 from enable.api import ComponentEditor
 from enable.savage.trait_defs.ui.svg_button import SVGButton
 from pyface.api import GUI
-from piksi_tools.console.utils import plot_square_axes, determine_path
+from piksi_tools.console.utils import plot_square_axes, determine_path, MultilineTextEditor
 
 import math
 import os
@@ -48,6 +48,8 @@ class SolutionView(HasTraits):
   dops_table = List()
   pos_table_spp = List()
   vel_table = List()
+
+  rtk_pos_note = Str("It is necessary to enter the \"Surveyed Position\" settings for the base station in order to view the psuedo-absolute RTK Positions in this tab.")
 
   plot = Instance(Plot)
   plot_data = Instance(ArrayPlotData)
@@ -92,7 +94,10 @@ class SolutionView(HasTraits):
           Item('', label='RTK Position', emphasized=True),
           Item('table_psuedo_abs',style='readonly',
                editor=TabularEditor(adapter=SimpleAdapter()),
-               show_label=False, width=0.3),
+               show_label=False, width=0.3, height=0.9),
+          Item('rtk_pos_note', show_label=False, resizable=True,
+            editor=MultilineTextEditor(TextEditor(multi_line=True)), 
+            style='readonly', width=0.3, height=-40),
           label='RTK Position')
       ),
       VGroup(

--- a/piksi_tools/console/utils.py
+++ b/piksi_tools/console/utils.py
@@ -12,6 +12,18 @@ import sys
 import traceback
 import os
 
+
+from traitsui.api import TextEditor
+
+class MultilineTextEditor(TextEditor):
+  """
+  Override of TextEditor Class for a multi-line read only
+  """
+
+  def init(self, parent):
+    parent.read_only = True
+    parent.multi_line = True
+
 def plot_square_axes(plot, xnames, ynames):
   try:
     if type(xnames) is str:


### PR DESCRIPTION
I added an annotation to the RTK Position tab in the console.  I get questions from users hourly about why this is blank.  Hopefully this message will help point users towards what needs to be done to get the psuedo-absolute position out.  This should close issue #62 

Please let me know if you have thoughts on the wording. (see photo below)

![image](https://cloud.githubusercontent.com/assets/11276774/11946133/3dcc0d16-a80c-11e5-8822-ad6f07c6d17f.png)

/cc @fnoble @mookerji @robhranac @drewshannon  