### PR TITLE
Sbp wrapper

### DIFF
--- a/piksi_tools/log_wrapper.py
+++ b/piksi_tools/log_wrapper.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+# Copyright (C) 2015 Swift Navigation Inc.
+# Contact: Dennis Zollo <dzollo@swift-nav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+import json
+import sys
+from piksi_tools.utils import wrap_sbp_dict
+
+def get_args():
+  parser = argparse.ArgumentParser(description="Swift Navigation JSON wrapper tool.")
+  return parser.parse_args()
+
+def main():
+  """Simple command line interface for wrapping up the output of SBP2JSON"
+
+  """
+  index = 0
+  timestamp = 0
+  time_increment_guess = 10 #ms
+  index_increment_guess = 10 #ms
+  for line in sys.stdin:
+    data = json.loads(line)
+    outdata = wrap_sbp_dict(data, index, timestamp)
+    print json.dumps(outdata)
+    index += index_increment_guess
+    timestamp += time_increment_guess
+
+if __name__ == "__main__":
+  main()

--- a/piksi_tools/utils.py
+++ b/piksi_tools/utils.py
@@ -149,3 +149,5 @@ def setup_piksi(handler, stm_fw, nap_fw, verbose=False):
     if verbose: print "Jumping to application"
     piksi_bootloader.jump_to_app()
 
+def wrap_sbp_dict(data_dict, timestamp, delta):
+  return {'data':data_dict, 'timestamp': timestamp, 'delta':delta}


### PR DESCRIPTION
this takes an SBP json log that has flat data fields and wraps it up with the original SBP information stored at the "data" key, whilst adding the timestamp and delta fields.  This allows a raw SBP binary log to be turned into a JSON log for use in the tools with the following command:

cat file | sbp2json  | log_wrapper.py > file.json

cc @mfine 