### PR TITLE
move import of piksi_tools.console.utils until after the toolkit was set

### DIFF
--- a/piksi_tools/console/console.py
+++ b/piksi_tools/console/console.py
@@ -15,10 +15,8 @@ import sbp.client as sbpc
 import signal
 import sys
 
-from piksi_tools.console.deprecated import DeprecatedMessageHandler
 from piksi_tools.serial_link import swriter, get_uuid, DEFAULT_BASE
 from piksi_tools.version import VERSION as CONSOLE_VERSION
-from piksi_tools.console.utils import determine_path
 from sbp.client.drivers.pyftdi_driver import PyFTDIDriver
 from sbp.client.drivers.pyserial_driver import PySerialDriver
 from sbp.ext_events import *
@@ -85,6 +83,7 @@ logging.basicConfig()
 from piksi_tools.console.output_list import OutputList, LogItem, str_to_log_level, \
   SYSLOG_LEVELS, DEFAULT_LOG_LEVEL_FILTER
 from piksi_tools.console.utils import determine_path
+from piksi_tools.console.deprecated import DeprecatedMessageHandler
 from traits.api import Str, Instance, Dict, HasTraits, Int, Button, List, Enum
 from traitsui.api import Item, Label, View, HGroup, VGroup, VSplit, HSplit, Tabbed, \
                          InstanceEditor, EnumEditor, ShellEditor, Handler, Spring, \


### PR DESCRIPTION
This should fix the error: 
Traceback (most recent call last):
  File "piksi_tools/console/console.py", line 80, in <module>
    ETSConfig.toolkit = 'qt4'
  File "/usr/lib/python2.7/dist-packages/traits/etsconfig/etsconfig.py", line 210, in _set_toolkit
    "already been set to %s" % (toolkit, self._toolkit)
ValueError: cannot set toolkit to qt4 because it has already been set to wx

The early traits import was causing the toolkit to be chosen before we could.

/cc @gsmcmullin @ljbade I think you guys had this problem and this should fix