### PR TITLE
Ubuntu 16.04 compatibility

### DIFF
--- a/requirements_gui.txt
+++ b/requirements_gui.txt
@@ -1,10 +1,10 @@
 http://effbot.org/downloads/Imaging-1.1.7.tar.gz
 chaco==4.4.1
-enable==4.4.1
-traits==4.5.0 
-traitsui==4.4.0 
-pyface==4.4.0 
-wsgiref==0.1.2 
+enable==4.5.1
+traits==4.5.0
+traitsui==4.4.0
+pyface==4.4.0
+wsgiref==0.1.2
 #pyside (required but installed through apt / brew)
 #sip (required but installed through apt / brew)
 #qt4 (required but installed through apt / brew)


### PR DESCRIPTION
On my Ubuntu 16.04 machine the current version of enable fails to install:

```
leith@leith-xps:~/swift/piksi_tools$ sudo pip install -r requirements_gui.txt
The directory '/home/leith/.cache/pip/http' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
The directory '/home/leith/.cache/pip' or its parent directory is not owned by the current user and caching wheels has been disabled. check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
Collecting http://effbot.org/downloads/Imaging-1.1.7.tar.gz (from -r requirements_gui.txt (line 1))
  Downloading http://effbot.org/downloads/Imaging-1.1.7.tar.gz (498kB)
    100% |████████████████████████████████| 501kB 192kB/s 
Collecting chaco==4.4.1 (from -r requirements_gui.txt (line 2))
  Downloading chaco-4.4.1.tar.gz (406kB)
    100% |████████████████████████████████| 409kB 338kB/s 
Collecting enable==4.4.1 (from -r requirements_gui.txt (line 3))
  Downloading enable-4.4.1.tar.gz (2.2MB)
    100% |████████████████████████████████| 2.3MB 283kB/s 
    Complete output from command python setup.py egg_info:
    /usr/local/lib/python2.7/dist-packages/numpy/distutils/system_info.py:635: UserWarning: Specified path /usr/local/include/python2.7 is invalid.
      warnings.warn('Specified path %s is invalid.' % d)
    /usr/local/lib/python2.7/dist-packages/numpy/distutils/system_info.py:635: UserWarning: Specified path  is invalid.
      warnings.warn('Specified path %s is invalid.' % d)
    non-existing path in 'kiva': 'tests'
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-hHsWvD/enable/setup.py", line 57, in <module>
        config = configuration().todict()
      File "/tmp/pip-build-hHsWvD/enable/setup.py", line 49, in configuration
        config.add_subpackage('kiva')
      File "/usr/local/lib/python2.7/dist-packages/numpy/distutils/misc_util.py", line 1002, in add_subpackage
        caller_level = 2)
      File "/usr/local/lib/python2.7/dist-packages/numpy/distutils/misc_util.py", line 971, in get_subpackage
        caller_level = caller_level + 1)
      File "/usr/local/lib/python2.7/dist-packages/numpy/distutils/misc_util.py", line 908, in _get_configuration_from_setup_py
        config = setup_module.configuration(*args)
      File "kiva/setup.py", line 27, in configuration
        config.add_subpackage('agg')
      File "/usr/local/lib/python2.7/dist-packages/numpy/distutils/misc_util.py", line 1002, in add_subpackage
        caller_level = 2)
      File "/usr/local/lib/python2.7/dist-packages/numpy/distutils/misc_util.py", line 971, in get_subpackage
        caller_level = caller_level + 1)
      File "/usr/local/lib/python2.7/dist-packages/numpy/distutils/misc_util.py", line 908, in _get_configuration_from_setup_py
        config = setup_module.configuration(*args)
      File "kiva/agg/setup.py", line 174, in configuration
        if int(m.group(1)) < 4:
    AttributeError: 'NoneType' object has no attribute 'group'

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-hHsWvD/enable/
```

Using enable 4.5.1 seems to fix this.

/cc @denniszollo 
