### PR TITLE
tracking.py: add filters for L1 vs L2 tracking

### DIFF
--- a/piksi_tools/console/tracking_view.py
+++ b/piksi_tools/console/tracking_view.py
@@ -68,7 +68,7 @@ class TrackingView(HasTraits):
              Spring(width=8, springy=False),  
              Item('show_l1', label = "Show L1:"),
              Spring(width=8, springy=False), 
-             Item('show_l2', label = "show L2:")),
+             Item('show_l2', label = "Show L2:")),
     )
   )
 

--- a/piksi_tools/console/tracking_view.py
+++ b/piksi_tools/console/tracking_view.py
@@ -11,54 +11,47 @@
 # WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 
 from chaco.api import ArrayPlotData, Plot
+import time
 from chaco.tools.api import LegendTool
 from enable.api import ComponentEditor
 from pyface.api import GUI
 from sbp.tracking import SBP_MSG_TRACKING_STATE
 from traits.api import Instance, Dict, HasTraits, Float, List, Int, Bool
-from traitsui.api import Item, View, HSplit, VGroup, HGroup
+from traitsui.api import Item, View, HSplit, VGroup, HGroup, Spring
 import numpy as np
 from piksi_tools.acq_results import SNR_THRESHOLD
-from piksi_tools.console.utils import code_to_str, code_is_gps
+from piksi_tools.console.utils import code_to_str, code_is_gps, L1_CODES, L2_CODES
 
 NUM_POINTS = 200
 
-colours_list = [
-  0xE41A1C,
-  0x377EB8,
-  0x4DAF4A,
-  0x984EA3,
-  0xFF7F00,
-  0xFFFF33,
-  0xA65628,
-  0xF781BF,
-]
+# These colors should be distinguishable from eachother
+color_dict = {'(0, 1)': 0xe58a8a, '(0, 2)': 0x664949, '(0, 3)': 0x590c00, 
+'(0, 4)': 0xcc4631, '(0, 5)': 0xe56c1c, '(0, 6)': 0x4c2a12, '(0, 7)': 0x996325, 
+'(0, 8)': 0xf2b774, '(0, 9)': 0xffaa00, '(0, 10)': 0xccb993, '(0, 11)': 0x997a00, 
+'(0, 12)': 0x4c4700, '(0, 13)': 0xd0d94e, '(0, 14)': 0xaaff00, '(0, 15)': 0x4ea614, 
+'(0, 16)': 0x123306, '(0, 17)': 0x18660c, '(0, 18)': 0x6e9974, '(0, 19)': 0x8ae6a2, 
+'(0, 20)': 0x00ff66, '(0, 21)': 0x57f2e8, '(0, 22)': 0x1f7980, '(0, 23)': 0x263e40, 
+'(0, 24)': 0x004d73, '(0, 25)': 0x37abe6, '(0, 26)': 0x7790a6, '(0, 27)': 0x144ea6, 
+'(0, 28)': 0x263040, '(0, 29)': 0x152859, '(0, 30)': 0x1d39f2, '(0, 31)': 0x828ed9, 
+'(0, 32)': 0x000073, '(1, 1)': 0x000066, '(1, 2)': 0x8c7aff, '(1, 3)': 0x1b0033, 
+'(1, 4)': 0xd900ca, '(1, 5)': 0x730e6c, '(1, 6)': 0x402e3f, '(1, 7)': 0xcc7abc, 
+'(1, 8)': 0xcc1978, '(1, 9)': 0x7f0033, '(1, 10)': 0xff1f5a, '(1, 11)': 0x330c11, 
+'(1, 12)': 0xcc627e, '(1, 13)': 0x73000f, '(1, 14)': 0x663d43, '(1, 15)': 0xd9b6bb, 
+'(1, 16)': 0xff0000, '(1, 17)': 0xf20000, '(1, 18)': 0xe56653, '(1, 19)': 0x4c1b09, 
+'(1, 20)': 0xffbfa8, '(1, 21)': 0xf2843a, '(1, 22)': 0x8c5b3b, '(1, 23)': 0x402d17, 
+'(1, 24)': 0xffdeb8, '(1, 25)': 0xd99e27, '(1, 26)': 0x736c0e, '(1, 27)': 0xfff23d, 
+'(1, 28)': 0x999777, '(1, 29)': 0xf1ffb8, '(1, 30)': 0x1f2610, '(1, 31)': 0x366600, 
+'(1, 32)': 0x71bf17
+}
 
 
-class TrackingState(HasTraits):
-  state = Int()
-  cn0 = Float()
-  prn = Int()
-  code = Int()
-
-  def __init__(self, *args, **kwargs):
-    self.update(*args, **kwargs)
-
-  def update(self, state, prn, cn0, code):
-    self.state = state
-    self.cn0 = 0 if cn0 == -1 else cn0
-    self.prn = prn
-    self.code = code
-
-  def __repr__(self):
-    return "TS: %d %f %d" % (self.prn, self.cn0, self.code)
 
 
 class TrackingView(HasTraits):
   python_console_cmds = Dict()
-  states = List(Instance(TrackingState))
-  cn0_history = List()
   legend_visible = Bool()
+  show_l1 = Bool(True)
+  show_l2 = Bool(True)
   plot = Instance(Plot)
   plots = List()
   plot_data = Instance(ArrayPlotData)
@@ -70,46 +63,75 @@ class TrackingView(HasTraits):
         editor=ComponentEditor(bgcolor=(0.8, 0.8, 0.8)),
         show_label=False,
       ),
-      HGroup(Item(' '), Item('legend_visible', label="Show Legend?")),
+      HGroup(Spring(width=4, springy=False), 
+             Item('legend_visible', label="Show Legend:"),
+             Spring(width=8, springy=False),  
+             Item('show_l1', label = "Show L1:"),
+             Spring(width=8, springy=False), 
+             Item('show_l2', label = "show L2:")),
     )
   )
 
   def tracking_state_callback(self, sbp_msg, **metadata):
-    n_channels = len(sbp_msg.states)
-    if n_channels != self.n_channels:
-      # Update number of channels
-      self.n_channels = n_channels
-      self.states = [TrackingState(0, 0, 0, 0) for _ in range(n_channels)]
-      for pl in self.plot.plots.iterkeys():
-        self.plot.delplot(pl.name)
-      self.plots = []
-      for n in range(n_channels):
-        self.plot_data.set_data('ch' + str(n), [0.0])
-        pl = self.plot.plot(('t', 'ch' + str(n)), type='line', color='auto',
-                            name='ch' + str(n))
-        self.plots.append(pl)
-      print 'Number of tracking channels changed to {0}'.format(n_channels)
-    for n, k in enumerate(self.states):
-      s = sbp_msg.states[n]
+    if self.first == True:
+      self.t_init = time.time()
+      self.first = False
+      self.time = range(-NUM_POINTS, 0, 1)
+    t = time.time() - self.t_init
+    self.time[0:-1] = self.time[1:]
+    self.time[-1] = t
+    # first we loop over all the SIDs / channel keys we have stored and set 0 in for CN0
+    for key, cno_array in self.CN0_dict.items():
+      # p
+      self.CN0_dict[key][0:-1] = cno_array[1:]
+      self.CN0_dict[key][-1] = 0
+      # If the whole array is 0 we remove it
+      if (cno_array==0).all():
+        self.CN0_dict.pop(key)
+    # for each satellite, we have a (code, prn, channel) keyed dict
+    # for each SID, an array of size MAX PLOT with the history of CN0's stored
+    # If there is no CN0 or not tracking for an epoch, 0 will be used
+    # each array can be plotted against host_time, t
+    for i,s in enumerate(sbp_msg.states):
       prn = s.sid.sat
       if code_is_gps(s.sid.code):
         prn += 1
-      k.update(s.state, prn, s.cn0, s.sid.code)
+      key = (s.sid.code, prn, i)
+      if len(self.CN0_dict.get(key, [])) == 0:
+        self.CN0_dict[key] = np.zeros(NUM_POINTS)
+      if s.state != 0:
+        self.CN0_dict[key][-1] = s.cn0
+      else:
+        self.CN0_dict[key][-1] = 0
     GUI.invoke_later(self.update_plot)
 
   def update_plot(self):
-    self.cn0_history.append([s.cn0 for s in self.states])
-    self.cn0_history = self.cn0_history[-1000:]
-
-    chans = np.transpose(self.cn0_history[-NUM_POINTS:])
     plot_labels = []
-    for n in range(self.n_channels):
-      self.plot_data.set_data('ch' + str(n), chans[n])
-      if self.states[n].state == 0:
-        plot_labels.append('Ch %02d (Disabled)' % n)
+    self.plots = []
+    self.plot_data.set_data('t', self.time)
+    # Remove any stale plots that got removed from the dictionary
+    for each in self.plot_data.list_data():
+      if each not in self.CN0_dict.items() and each != 't':
+        self.plot_data.del_data(str(each))
+        self.plot.delplot(str(each))
+    for key, cno_array in self.CN0_dict.items():
+      # set plot data and create plot for any selected for display
+      if ((self.show_l2 and key[0] in L2_CODES) or
+          (self.show_l1 and key[0] in L1_CODES)):
+          self.plot_data.set_data(str(key), cno_array)
+          pl = self.plot.plot(('t', str(key)), type='line', color=color_dict[str((key[0],key[1]))],
+                              name=str(key))
+          # if channel is still active:
+          if cno_array[-1] != 0:
+            self.plots.append(pl)
+            plot_labels.append('Ch %02d (PRN%02d (%s))' %
+            (key[2], key[1], code_to_str(key[0])))
+      # Remove plot data and plots not selected
       else:
-        plot_labels.append('Ch %02d (PRN%02d (%s))' %
-          (n, self.states[n].prn, code_to_str(self.states[n].code)))
+        if str(key) in self.plot_data.list_data():
+          self.plot_data.del_data(str(key))
+        if str(key) in self.plot.plots:
+          self.plot.delplot(str(key))
     plots = dict(zip(plot_labels, self.plots))
     self.plot.legend.plots = plots
 
@@ -124,9 +146,12 @@ class TrackingView(HasTraits):
 
   def __init__(self, link):
     super(TrackingView, self).__init__()
+    self.first = True
+    self.time = np.empty(NUM_POINTS)
+    self.CN0_dict = {}
     self.n_channels = None
     self.plot_data = ArrayPlotData(t=[0.0])
-    self.plot = Plot(self.plot_data, auto_colors=colours_list, emphasized=True)
+    self.plot = Plot(self.plot_data, emphasized=True)
     self.plot.title = 'Tracking C/N0'
     self.plot.title_color = [0, 0, 0.43]
     self.ylim = self.plot.value_mapper.range
@@ -136,8 +161,8 @@ class TrackingView(HasTraits):
     self.plot.value_axis.orientation = 'right'
     self.plot.value_axis.axis_line_visible = False
     self.plot.value_axis.title = 'dB-Hz'
-    t = range(NUM_POINTS)
-    self.plot_data.set_data('t', t)
+    #t = range(NUM_POINTS)
+    self.plot_data.set_data('t', self.time)
     self.legend_visible = True
     self.plot.legend.visible = True
     self.plot.legend.align = 'll'

--- a/piksi_tools/console/utils.py
+++ b/piksi_tools/console/utils.py
@@ -23,7 +23,7 @@ L2CM = 'L2CM'
 L1P = 'L1P'
 L2P = 'L2P'
 CODE_NOT_AVAILABLE = 'N/A'
-EMPTY_STR = '---'
+EMPTY_STR = '--'
 
 FIXED_MODE  = 4
 FLOAT_MODE  = 3
@@ -45,6 +45,8 @@ color_dict = {
  FLOAT_MODE: (0.75, 0, 0.75),
  FIXED_MODE: 'orange'}
 
+L1_CODES = [0,2,3]
+L2_CODES = [1,4]
 
 def code_to_str(code):
   if code == 0:


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/11276774/20853393/7082251a-b8a0-11e6-9cb3-b58710e2f9a0.png)


Allows one to reduce clutter on tracking display by showing only l1 or l2 signals
Also tries to make all colors unique.

If a satellite is no longer tracked, its label is removed from the legend