### PR TITLE
Console based firmware update for Piksi Multi

### DIFF
--- a/piksi_tools/console/update_downloader.py
+++ b/piksi_tools/console/update_downloader.py
@@ -43,6 +43,16 @@ class UpdateDownloader:
       raise URLError("Error: Failed to download latest NAP firmware from Swift Navigation's website")
     return filepath
 
+  def download_multi_firmware(self):
+    try:
+      url = self.index['piksi_multi']['fw']['url']
+      filepath = self._download_file_from_url(url)
+    except KeyError:
+      raise KeyError("Error downloading firmware: URL not present in index")
+    except URLError:
+      raise URLError("Error: Failed to download latest NAP firmware from Swift Navigation's website")
+    return filepath
+
   def _download_file_from_url(self, url):
     url = url.encode('ascii')
     urlpath = urlparse(url).path

--- a/piksi_tools/console/update_downloader.py
+++ b/piksi_tools/console/update_downloader.py
@@ -23,9 +23,9 @@ class UpdateDownloader:
     self.index = jsonload(f)
     f.close()
 
-  def download_stm_firmware(self):
+  def download_stm_firmware(self, hwrev):
     try:
-      url = self.index['piksi_v2.3.1']['stm_fw']['url']
+      url = self.index[hwrev]['stm_fw']['url']
       filepath = self._download_file_from_url(url)
     except KeyError:
       raise KeyError("Error downloading firmware: URL not present in index")
@@ -33,9 +33,9 @@ class UpdateDownloader:
       raise URLError("Error: Failed to download latest NAP firmware from Swift Navigation's website")
     return filepath
 
-  def download_nap_firmware(self):
+  def download_nap_firmware(self, hwrev):
     try:
-      url = self.index['piksi_v2.3.1']['nap_fw']['url']
+      url = self.index[hwrev]['nap_fw']['url']
       filepath = self._download_file_from_url(url)
     except KeyError:
       raise KeyError("Error downloading firmware: URL not present in index")
@@ -43,9 +43,9 @@ class UpdateDownloader:
       raise URLError("Error: Failed to download latest NAP firmware from Swift Navigation's website")
     return filepath
 
-  def download_multi_firmware(self):
+  def download_multi_firmware(self, hwrev):
     try:
-      url = self.index['piksi_multi']['fw']['url']
+      url = self.index[hwrev]['fw']['url']
       filepath = self._download_file_from_url(url)
     except KeyError:
       raise KeyError("Error downloading firmware: URL not present in index")

--- a/piksi_tools/console/update_downloader.py
+++ b/piksi_tools/console/update_downloader.py
@@ -30,7 +30,7 @@ class UpdateDownloader:
     except KeyError:
       raise KeyError("Error downloading firmware: URL not present in index")
     except URLError:
-      raise URLError("Error: Failed to download latest NAP firmware from Swift Navigation's website")
+      raise URLError("Error: Failed to download latest STM firmware from Swift Navigation's website")
     return filepath
 
   def download_nap_firmware(self, hwrev):
@@ -50,7 +50,7 @@ class UpdateDownloader:
     except KeyError:
       raise KeyError("Error downloading firmware: URL not present in index")
     except URLError:
-      raise URLError("Error: Failed to download latest NAP firmware from Swift Navigation's website")
+      raise URLError("Error: Failed to download latest Multi firmware from Swift Navigation's website")
     return filepath
 
   def _download_file_from_url(self, url):

--- a/piksi_tools/console/update_view.py
+++ b/piksi_tools/console/update_view.py
@@ -171,6 +171,7 @@ class PulsableProgressDialog(ProgressDialog):
     sleep(0.2)
 
 class UpdateView(HasTraits):
+  piksi_hw_rev = String('Waiting for Piksi to send settings...')
 
   piksi_stm_vers = String('Waiting for Piksi to send settings...', width=COLUMN_WIDTH)
   newest_stm_vers = String('Downloading Newest Firmware info...')
@@ -204,6 +205,7 @@ class UpdateView(HasTraits):
 
   view = View(
     VGroup(
+      Item('piksi_hw_rev', label='Hardware Revision', resizable=True),
       HGroup(
         VGroup(
           Item('piksi_stm_vers', label='Current', resizable=True),
@@ -446,6 +448,8 @@ class UpdateView(HasTraits):
     """
     # Check that settings received from Piksi contain FW versions.
     try:
+      self.piksi_hw_rev = \
+        self.settings['system_info']['hw_revision'].value
       self.piksi_stm_vers = \
         self.settings['system_info']['firmware_version'].value
       self.piksi_nap_vers = \

--- a/piksi_tools/console/update_view.py
+++ b/piksi_tools/console/update_view.py
@@ -309,7 +309,6 @@ class UpdateView(HasTraits):
     self.nap_fw = FirmwareFileDialog('M25')
     self.nap_fw.on_trait_change(self._manage_enables, 'status')
     self.stream = OutputStream()
-    self.get_latest_version_info()
 
   def _manage_enables(self):
     """ Manages whether traits widgets are enabled in the UI or not. """
@@ -506,10 +505,8 @@ class UpdateView(HasTraits):
     """
     # Check that settings received from Piksi contain FW versions.
     try:
-      tmp = HW_REV_LOOKUP[self.settings['system_info']['hw_revision'].value]
-      if self.piksi_hw_rev != tmp:
-        self.get_latest_version_info()
-      self.piksi_hw_rev = tmp
+      self.piksi_hw_rev = \
+        HW_REV_LOOKUP[self.settings['system_info']['hw_revision'].value]
       self.piksi_stm_vers = \
         self.settings['system_info']['firmware_version'].value
       self.piksi_nap_vers = \
@@ -523,6 +520,8 @@ class UpdateView(HasTraits):
       self.stm_fw.set_flash_type('STM')
     else:
       self.stm_fw.set_flash_type('bin')
+
+    self._get_latest_version_info()
 
     # Check that we received the index file from the website.
     if self.update_dl == None:
@@ -594,20 +593,6 @@ class UpdateView(HasTraits):
                 self.update_dl.index[self.piksi_hw_rev]['nap_fw']['version']
 
         fw_update_prompt.run()
-
-  def get_latest_version_info(self):
-    """
-    Get latest firmware / console version from website. Starts thread so as not
-    to block the GUI thread.
-    """
-    try:
-      if self._get_latest_version_info_thread.is_alive():
-        return
-    except AttributeError:
-      pass
-
-    self._get_latest_version_info_thread = Thread(target=self._get_latest_version_info)
-    self._get_latest_version_info_thread.start()
 
   def _get_latest_version_info(self):
     """ Get latest firmware / console version from website. """

--- a/piksi_tools/console/update_view.py
+++ b/piksi_tools/console/update_view.py
@@ -448,6 +448,8 @@ class UpdateView(HasTraits):
     """
     # Check that settings received from Piksi contain FW versions.
     try:
+      if self.piksi_hw_rev !=self.settings['system_info']['hw_revision'].value:
+        self.get_latest_version_info()
       self.piksi_hw_rev = \
         self.settings['system_info']['hw_revision'].value
       self.piksi_stm_vers = \
@@ -485,7 +487,7 @@ class UpdateView(HasTraits):
             "Local Console Version :\n\t" + \
                 "v" + CONSOLE_VERSION + \
             "\nNewest Console Version :\n\t" + \
-                self.update_dl.index['piksi_v2.3.1']['console']['version'] + "\n"
+                self.update_dl.index[self.piksi_hw_rev]['console']['version'] + "\n"
 
         console_outdated_prompt.run()
 
@@ -516,9 +518,9 @@ class UpdateView(HasTraits):
             "New Piksi firmware available.\n\n" + \
             "Please use the Firmware Update tab to update.\n\n" + \
             "Newest STM Version :\n\t%s\n\n" % \
-                self.update_dl.index['piksi_v2.3.1']['stm_fw']['version'] + \
+                self.update_dl.index[self.piksi_hw_rev]['stm_fw']['version'] + \
             "Newest SwiftNAP Version :\n\t%s\n\n" % \
-                self.update_dl.index['piksi_v2.3.1']['nap_fw']['version']
+                self.update_dl.index[self.piksi_hw_rev]['nap_fw']['version']
 
         fw_update_prompt.run()
 
@@ -546,9 +548,12 @@ class UpdateView(HasTraits):
 
     # Make sure index contains all keys we are interested in.
     try:
-      self.newest_stm_vers = self.update_dl.index['piksi_v2.3.1']['stm_fw']['version']
-      self.newest_nap_vers = self.update_dl.index['piksi_v2.3.1']['nap_fw']['version']
-      self.newest_console_vers = self.update_dl.index['piksi_v2.3.1']['console']['version']
+      if self.update_dl.index[self.piksi_hw_rev].has_key('fw'):
+        self.newest_stm_vers = self.update_dl.index[self.piksi_hw_rev]['fw']['version']
+      else:
+        self.newest_stm_vers = self.update_dl.index[self.piksi_hw_rev]['stm_fw']['version']
+        self.newest_nap_vers = self.update_dl.index[self.piksi_hw_rev]['nap_fw']['version']
+      self.newest_console_vers = self.update_dl.index[self.piksi_hw_rev]['console']['version']
     except KeyError:
       self._write("\nError: Index downloaded from Swift Navigation's website (%s) doesn't contain all keys. Please contact Swift Navigation.\n" % INDEX_URL)
       return

--- a/piksi_tools/console/update_view.py
+++ b/piksi_tools/console/update_view.py
@@ -29,7 +29,7 @@ from piksi_tools import flash
 import piksi_tools.console.callback_prompt as prompt
 from piksi_tools.console.utils import determine_path
 
-from update_downloader import UpdateDownloader
+from update_downloader import UpdateDownloader, INDEX_URL
 from output_stream import OutputStream
 
 import sys, os
@@ -44,7 +44,6 @@ else:
 icon = ImageResource('icon',
          search_path=['images', os.path.join(basedir, 'images')])
 
-INDEX_URL = 'http://downloads.swiftnav.com/index.json'
 HT = 8
 COLUMN_WIDTH = 100
 

--- a/piksi_tools/console/update_view.py
+++ b/piksi_tools/console/update_view.py
@@ -519,7 +519,14 @@ class UpdateView(HasTraits):
                                   actions=[prompt.close_button]
                                  )
 
-        fw_update_prompt.text = \
+        if self.update_dl.index[self.piksi_hw_rev].has_key('fw'):
+          fw_update_prompt.text = \
+            "New Piksi firmware available.\n\n" + \
+            "Please use the Firmware Update tab to update.\n\n" + \
+            "Newest Firmware Version :\n\t%s\n\n" % \
+                self.update_dl.index[self.piksi_hw_rev]['fw']['version']
+        else:
+          fw_update_prompt.text = \
             "New Piksi firmware available.\n\n" + \
             "Please use the Firmware Update tab to update.\n\n" + \
             "Newest STM Version :\n\t%s\n\n" % \

--- a/piksi_tools/console/update_view.py
+++ b/piksi_tools/console/update_view.py
@@ -382,9 +382,26 @@ class UpdateView(HasTraits):
     self._write(status)
 
     # Get firmware files from Swift Nav's website, save to disk, and load.
+    if self.update_dl.index[self.piksi_hw_rev].has_key('fw'):
+      try:
+        self._write('Downloading Newest Multi firmware')
+        filepath = self.update_dl.download_multi_firmware(self.piksi_hw_rev)
+        self._write('Saved file to %s' % filepath)
+      except AttributeError:
+        self.nap_fw.clear("Error downloading firmware")
+        self._write("Error downloading firmware: index file not downloaded yet")
+      except KeyError:
+        self.nap_fw.clear("Error downloading firmware")
+        self._write("Error downloading firmware: URL not present in index")
+      except URLError:
+        self.nap_fw.clear("Error downloading firmware")
+        self._write("Error: Failed to download latest NAP firmware from Swift Navigation's website")
+      self.downloading = False
+      return
+
     try:
       self._write('Downloading Newest NAP firmware')
-      filepath = self.update_dl.download_nap_firmware()
+      filepath = self.update_dl.download_nap_firmware(self.piksi_hw_rev)
       self._write('Saved file to %s' % filepath)
       self.nap_fw.load_ihx(filepath)
     except AttributeError:
@@ -399,7 +416,7 @@ class UpdateView(HasTraits):
 
     try:
       self._write('Downloading Newest STM firmware')
-      filepath = self.update_dl.download_stm_firmware()
+      filepath = self.update_dl.download_stm_firmware(self.piksi_hw_rev)
       self._write('Saved file to %s' % filepath)
       self.stm_fw.load_ihx(filepath)
     except AttributeError:

--- a/piksi_tools/console/update_view.py
+++ b/piksi_tools/console/update_view.py
@@ -172,6 +172,7 @@ class PulsableProgressDialog(ProgressDialog):
 
 class UpdateView(HasTraits):
   piksi_hw_rev = String('Waiting for Piksi to send settings...')
+  is_v2 = Bool(False)
 
   piksi_stm_vers = String('Waiting for Piksi to send settings...', width=COLUMN_WIDTH)
   newest_stm_vers = String('Downloading Newest Firmware info...')
@@ -205,7 +206,8 @@ class UpdateView(HasTraits):
 
   view = View(
     VGroup(
-      Item('piksi_hw_rev', label='Hardware Revision', resizable=True),
+      Item('piksi_hw_rev', label='Hardware Revision',
+           editor_args={'enabled': False}, resizable=True),
       HGroup(
         VGroup(
           Item('piksi_stm_vers', label='Current', resizable=True),
@@ -215,7 +217,7 @@ class UpdateView(HasTraits):
           HGroup(Item('update_stm_firmware', show_label=False, \
                      enabled_when='update_stm_en'),
                 Item('erase_stm', label='Erase STM flash\n(recommended)', \
-                      enabled_when='erase_en', show_label=True)),
+                      enabled_when='erase_en', show_label=True, visible_when='is_v2')),
           show_border=True, label="STM Firmware Version"
         ),
         VGroup(
@@ -226,7 +228,8 @@ class UpdateView(HasTraits):
           HGroup(Item('update_nap_firmware', show_label=False, \
                       enabled_when='update_nap_en'),
                  Item(width=50, label="                  ")),
-          show_border=True, label="NAP Firmware Version"
+          show_border=True, label="NAP Firmware Version",
+          visible_when='is_v2'
           ),
         VGroup(
           Item('local_console_vers', label='Current', resizable=True),
@@ -234,7 +237,7 @@ class UpdateView(HasTraits):
           label="Piksi Console Version", show_border=True),
           ),
       UItem('download_firmware', enabled_when='download_fw_en'),
-      UItem('update_full_firmware', enabled_when='update_en'),
+      UItem('update_full_firmware', enabled_when='update_en', visible_when='is_v2'),
       Item(
         'stream',
         style='custom',
@@ -459,6 +462,8 @@ class UpdateView(HasTraits):
     except KeyError:
       self._write("\nError: Settings received from Piksi don't contain firmware version keys. Please contact Swift Navigation.\n")
       return
+
+    self.is_v2 = self.piksi_hw_rev.startswith('piksi_2')
 
     # Check that we received the index file from the website.
     if self.update_dl == None:

--- a/piksi_tools/console/update_view.py
+++ b/piksi_tools/console/update_view.py
@@ -221,7 +221,7 @@ class UpdateView(HasTraits):
   erase_stm = Bool(True)
   erase_en = Bool(True)
 
-  update_stm_firmware = Button(label='Update STM')
+  update_stm_firmware = Button(label='Update FW')
   update_nap_firmware = Button(label='Update NAP')
   update_full_firmware = Button(label='Update Piksi STM and NAP Firmware')
 
@@ -255,7 +255,7 @@ class UpdateView(HasTraits):
                      enabled_when='update_stm_en'),
                 Item('erase_stm', label='Erase STM flash\n(recommended)', \
                       enabled_when='erase_en', show_label=True, visible_when='is_v2')),
-          show_border=True, label="STM Firmware Version"
+          show_border=True, label="Firmware Version"
         ),
         VGroup(
           Item('piksi_nap_vers', label='Current', resizable=True),
@@ -265,7 +265,7 @@ class UpdateView(HasTraits):
           HGroup(Item('update_nap_firmware', show_label=False, \
                       enabled_when='update_nap_en'),
                  Item(width=50, label="                  ")),
-          show_border=True, label="NAP Firmware Version",
+          show_border=True, label="NAP Version",
           visible_when='is_v2'
           ),
         VGroup(

--- a/piksi_tools/console/update_view.py
+++ b/piksi_tools/console/update_view.py
@@ -686,8 +686,13 @@ class UpdateView(HasTraits):
     progress_dialog.title = "Transferring image file"
     GUI.invoke_later(progress_dialog.open)
     self._write("Transferring image file...")
-    FileIO(self.link).write("upgrade.image_set.bin", self.stm_fw.blob,
-                            progress_cb=progress_dialog.progress)
+    try:
+      FileIO(self.link).write("upgrade.image_set.bin", self.stm_fw.blob,
+                              progress_cb=progress_dialog.progress)
+    except Exception as e:
+      self._write("Failed to transfer image file to Piksi: %s\n" % e)
+      progress_dialog.close()
+      return
     progress_dialog.close()
 
     # Setup up pulsed progress dialog and commit to flash


### PR DESCRIPTION
Changes to the update view to allow updating of Piksi Multi firmware from the console.
The hardware revision read from the Piksi in the settings is used to distinguish between Piksi v2.3.1 and Piksi Multi.  The index.json file is downloaded as before, and support is added for binary firmware files, and the Piksi Multi update mechanism transferring the file to Piksi using SBP FileIO, and committing it to flash with SBP command.

When Piksi Multi is detected, Piksi v2.3.1 only options (erase flash and NAP update) are hidden from the UI:
![image](https://cloud.githubusercontent.com/assets/466364/21084738/2dc0831e-c06d-11e6-8b42-e56b14d25f2a.png)

