### PR TITLE
update_view improvements and hiding of feature

### DIFF
--- a/piksi_tools/console/console.py
+++ b/piksi_tools/console/console.py
@@ -367,7 +367,7 @@ class SwiftConsole(HasTraits):
       "good" if (e.flags & (1<<1)) else "unknown")
 
   def cmd_resp_callback(self, sbp_msg, **metadata):
-    r = MsgCmdResponse(sbp_msg)
+    r = MsgCommandResp(sbp_msg)
     print "Received a command response message with code {0}".format(
            r.code)
 

--- a/piksi_tools/console/console.py
+++ b/piksi_tools/console/console.py
@@ -84,6 +84,8 @@ def get_args():
                       help="Log console stdout/err to file.")
   parser.add_argument('--skylark', default='',
                       help="key value pairs to pass to sbp_relay_view initializer for skylark")
+  parser.add_argument('--serial-upgrade', action='store_true',
+                      help="Allow software upgrade over serial.")
   return parser.parse_args()
 
 args = get_args()
@@ -497,7 +499,8 @@ class SwiftConsole(HasTraits):
     self.console_output.close()
   
   def __init__(self, link, update, log_level_filter, skip_settings=False, error=False, 
-               port=None, json_logging=False, log_dirname=None, log_console=False, skylark=""):
+               port=None, json_logging=False, log_dirname=None, log_console=False, skylark="",
+               serial_upgrade=False):
     self.error = error
     self.port = port
     self.dev_id = str(os.path.split(port)[1])
@@ -545,7 +548,7 @@ class SwiftConsole(HasTraits):
       self.observation_view = ObservationView(self.link, name='Local', relay=False, dirname=self.directory_name)
       self.observation_view_base = ObservationView(self.link, name='Remote', relay=True, dirname=self.directory_name)
       self.system_monitor_view = SystemMonitorView(self.link)
-      self.update_view = UpdateView(self.link, prompt=update)
+      self.update_view = UpdateView(self.link, prompt=update, serial_upgrade=serial_upgrade)
       self.imu_view = IMUView(self.link)
       settings_read_finished_functions.append(self.update_view.compare_versions)
       if skylark:
@@ -674,7 +677,7 @@ with selected_driver as driver:
     
     with SwiftConsole(link, args.update, log_filter, port=port, error=args.error, 
                  json_logging=args.log, log_dirname=args.log_dirname[0], log_console=args.log_console,
-                 skylark=args.skylark) as console: 
+                 skylark=args.skylark, serial_upgrade=args.serial_upgrade) as console: 
       console.configure_traits()
 
 # Force exit, even if threads haven't joined

--- a/piksi_tools/console/update_downloader.py
+++ b/piksi_tools/console/update_downloader.py
@@ -18,10 +18,14 @@ INDEX_URL = 'http://downloads.swiftnav.com/index.json'
 
 class UpdateDownloader:
 
-  def __init__(self):
+  def __init__(self, root_dir=''):
     f = urlopen(INDEX_URL)
     self.index = jsonload(f)
+    self.root_dir = ''
     f.close()
+
+  def set_root_path(self, path):
+    self.root_dir = path
 
   def download_stm_firmware(self, hwrev):
     try:
@@ -57,7 +61,7 @@ class UpdateDownloader:
     url = url.encode('ascii')
     urlpath = urlparse(url).path
     filename = os.path.split(urlparse(url).path)[1]
-
+    filename = os.path.join(self.root_dir, filename)
     url_file = urlopen(url)
     blob = url_file.read()
     with open(filename, 'wb') as f:

--- a/piksi_tools/console/update_view.py
+++ b/piksi_tools/console/update_view.py
@@ -334,14 +334,11 @@ class UpdateView(HasTraits):
       self.stream.write(
            "Please choose the usb flashdrive root directory and press the "
            "Download Latest Firmware button.  This will download the latest "
-           "Piksi Multi firmware file onto " 
-           "the usb flashdrive provided with your Piksi Multi. Eject " 
-           "the drive from the PC and plug it into the evaluation board.\n\n"
-           "Reset your Piksi and it will upgrade to the version on the flashdrive. " 
-           "During the upgrade, you should receive info messages in the console. "
-           "When the upgrade completes the .bin firmware file will be "
-           "deleted from the flash drive and expected version should be "
-           "reflected above.")
+           "Piksi Multi firmware file onto the usb flashdrive provided with "
+           "your Piksi Multi. Eject the drive from the PC and plug it into the evaluation board.\n\n"
+           "Reboot your Piksi and it will upgrade to the version on the usb flashdrive. "
+           "When the upgrade completes you will be prompted to remove the usb flashdrive "
+           "and reboot your Piksi Multi.")
 
   def _manage_enables(self):
     """ Manages whether traits widgets are enabled in the UI or not. """

--- a/piksi_tools/console/update_view.py
+++ b/piksi_tools/console/update_view.py
@@ -730,12 +730,15 @@ class UpdateView(HasTraits):
     self._write("Committing file to flash...")
     def log_cb(msg, **kwargs): self._write(msg.text)
     self.link.add_callback(log_cb, SBP_MSG_LOG)
-    code = shell_command(self.link, "upgrade_tool upgrade.image_set.bin", 240)
+    code = shell_command(self.link, "upgrade_tool upgrade.image_set.bin", 600,
+                         progress_cb=progress_dialog.progress)
     self.link.remove_callback(log_cb, SBP_MSG_LOG)
     progress_dialog.close()
 
     if code != 0:
       self._write('Failed to perform upgrade (code = %d)' % code)
+      if code == -255:
+        self._write('Shell command timed out.  Please try again.')
       return
     self._write('Resetting Piksi...')
     self.link(MsgReset(flags=0))

--- a/piksi_tools/console/utils.py
+++ b/piksi_tools/console/utils.py
@@ -98,7 +98,7 @@ class MultilineTextEditor(TextEditor):
   Override of TextEditor Class for a multi-line read only
   """
 
-  def init(self, parent):
+  def init(self, parent=TextEditor(multi_line=True)):
     parent.read_only = True
     parent.multi_line = True
 

--- a/piksi_tools/fileio.py
+++ b/piksi_tools/fileio.py
@@ -202,12 +202,17 @@ class FileIO(object):
 
     # How do we calculate this from the MsgFileioWriteRequest class?
     chunksize = MAX_PAYLOAD_SIZE - len(filename) - 9
+    current_index=0
 
     with SelectiveRepeater(self.link, SBP_MSG_FILEIO_WRITE_RESP) as sr:
-      while data:
+      while offset < len(data):
         seq = self.next_seq()
-        chunk = data[:chunksize]
-        data = data[chunksize:]
+        end_index = offset+chunksize-1
+        if end_index > len(data):
+          end_index = len(data)
+        #print "going from {0} to {1} in array for chunksize {2}".format(offset, end_index, chunksize)
+        chunk = data[offset:offset+chunksize-1]
+        #print "len is {0}".format(len(chunk))
         msg = MsgFileioWriteReq(sequence=seq,
                                 filename=(filename + '\0' + chunk),
                                 offset=offset, data='')


### PR DESCRIPTION
- Improved speed and monitoring of serial upgrade; now hidden but still useful for future.
- Hidden update view without special command line option. 
- if the --serial-upgrade command line argument is passed, the instructions disappear and the serial upgrade functionality comes back.

Now the update view for piksi multi looks like screenshot below.  There is a text blob of instructions for how to upgrade, and the user can specify where to download files.  I'm looking for feedback on the text blob if you have any thoughts.

![image](https://cloud.githubusercontent.com/assets/11276774/21704532/e6e2da72-d36e-11e6-9d4c-10f2b365ea73.png)


/cc @gsmcmullin @cbeighley @switanis @jkretzmer @jdormoy 
