### PR TITLE
Udev rules

### DIFF
--- a/piksi_tools/console/pyinstaller/Makefile
+++ b/piksi_tools/console/pyinstaller/Makefile
@@ -32,8 +32,8 @@ Cygwin:
 Darwin:
 	sudo ./create-dmg-installer.sh
 Linux:
-	tar cfvz swift_console_v$(VERSION).tar.gz ./dist/console 
-	mv swift_console_v$(VERSION).tar.gz ./dist/
+	mv ./dist/console ./dist/swift_console_v$(VERSION)
+	cd dist && tar cfvz swift_console_v$(VERSION).tar.gz ./swift_console_v$(VERSION)
 clean:
 	rm -rf build dist
 

--- a/piksi_tools/console/pyinstaller/console.spec
+++ b/piksi_tools/console/pyinstaller/console.spec
@@ -44,6 +44,7 @@ a = Analysis(['../console.py'],
 resources = [
   ('settings.yaml', '../settings.yaml', 'DATA'),
   ('RELEASE-VERSION', '../../RELEASE-VERSION', 'DATA'),
+  ('configure_udev_rules.sh', '../../../tasks/configure_udev_rules.sh', 'DATA'),
 ]
 resources += Tree('../images', prefix='piksi_tools/console/images')
 

--- a/tasks/configure_udev_rules.sh
+++ b/tasks/configure_udev_rules.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+current_user="$USER"
+echo "Creating new udev rule 99-piksi.rules with the following lines"
+sudo tee /etc/udev/rules.d/99-piksi.rules <<EOF
+ATTRS{idProduct}=="6014", ATTRS{idVendor}=="0403", MODE="666", GROUP="dialout"
+ATTRS{idProduct}=="8398", ATTRS{idVendor}=="0403", MODE="666", GROUP="dialout"
+ATTRS{idProduct}=="A4A7", ATTRS{idVendor}=="0525", MODE="666", GROUP="dialout"
+EOF
+echo "Adding current user to the dialout group."
+sudo usermod -a -G dialout $current_user 
+echo "reloading udev rules"
+sudo udevadm control --reload-rules


### PR DESCRIPTION
this adds a shell script for configuring udev rules for piksi v2 and piksi multi for user convenience on linux

It also adds the shell script to the pyinstaller package so it will come down with our TARs for linux.

Tested to work on Mufasa (provided the user can sudo).

Would it be better to not have the explicit sudo and make the user figure that out?

/cc @stefan