### PR TITLE
Different versions of PyInstaller for linux and osx

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,11 +11,7 @@ pylibftdi==0.14.2
 pyparsing==1.5.7
 pygments==2.0.2
 requests>=2.8.1
-# Required for windows pyinstaller
 kiwisolver>=0.1.3
 six>=1.10.0
 construct==2.5.2
 sbp==2.1.5
-# pyinstaller requirements
-pyinstaller>=3.0
-# cryptography>=1.1.1

--- a/tasks/setup.sh
+++ b/tasks/setup.sh
@@ -78,6 +78,7 @@ function all_dependencies_debian () {
          python-software-properties
     sudo pip install -r ../requirements.txt
     sudo pip install -r ../requirements_gui.txt
+    sudo pip install PyInstaller==3.1
 }
 
 
@@ -158,6 +159,7 @@ function install_python_deps_osx () {
     brew link openssl --forcea
     pip install -r ../requirements.txt
     pip install -r ../requirements_gui.txt
+    pip install PyInstaller==3.2
 }
 
 


### PR DESCRIPTION
for osx latest pyinstaller is working

for linux 3.1 is the only one that is working


This chooses between them so travis can autobuild us functional binaries.