### PR TITLE
update_view: don't look for nap version keys

### DIFF
--- a/piksi_tools/console/update_view.py
+++ b/piksi_tools/console/update_view.py
@@ -547,8 +547,6 @@ class UpdateView(HasTraits):
         HW_REV_LOOKUP[self.settings['system_info']['hw_revision'].value]
       self.piksi_stm_vers = \
         self.settings['system_info']['firmware_version'].value
-      self.piksi_nap_vers = \
-        self.settings['system_info']['nap_version'].value
     except KeyError:
       self._write("\nError: Settings received from Piksi don't contain firmware version keys. Please contact Swift Navigation.\n")
       return


### PR DESCRIPTION
this should get rid of this annoying message:
![image](https://cloud.githubusercontent.com/assets/11276774/21871407/bd327af0-d816-11e6-902b-89c040115e7c.png)
