### PR TITLE
USB upgrade UI improvements (release)

### DIFF
--- a/piksi_tools/console/update_view.py
+++ b/piksi_tools/console/update_view.py
@@ -231,7 +231,7 @@ class UpdateView(HasTraits):
   update_nap_en = Bool(False)
   update_en = Bool(False)
   serial_upgrade = Bool(False)
-  upgrade_instructions = String("Firmware upgrade instructions:")
+  upgrade_steps = String("Firmware upgrade steps:")
 
   download_firmware = Button(label='Download Latest Firmware')
   download_directory = Directory("  Please choose a directory for downloaded firmware files...")
@@ -291,7 +291,7 @@ class UpdateView(HasTraits):
       UItem('download_firmware', enabled_when='download_fw_en'),
       UItem('update_full_firmware', enabled_when='update_en', visible_when='is_v2'),
       VGroup(
-        UItem('upgrade_instructions', 
+        UItem('upgrade_steps', 
               visible_when='not serial_upgrade', style='readonly'),
         Item(
           'stream',
@@ -335,18 +335,22 @@ class UpdateView(HasTraits):
     self.serial_upgrade = serial_upgrade
     if not self.serial_upgrade:
       self.stream.write(
-           "Insert the USB flash drive provided with your Piki Multi into " 
+           "1. Insert the USB flash drive provided with your Piki Multi into "
            "your computer.  Select the flash drive root directory as the "
            "firmware download destination using the \"Please "
            "choose a directory for downloaded firmware files\" directory "
            "chooser above.  Press the \"Download Latest Firmware\" button.  "
            "This will download the latest Piksi Multi firmware file onto the "
-           "USB flashdrive.  Eject the drive from your computer and plug it "
-           "into the Piksi Multi evaluation board.  "
-           "Reboot your Piksi Multi and it will upgrade to the version on the "
-           "USB flash drive.  "
-           "When the upgrade completes you will be prompted to remove the USB flash drive "
-           "and reboot your Piksi Multi.")
+           "USB flashdrive.\n"
+           "2. Eject the drive from your computer and plug it "
+           "into the Piksi Multi evaluation board.\n"
+           "3. Reset your Piksi Multi and it will upgrade to the version "
+           "on the USB flash drive. This should take less than 5 minutes.\n"
+           "4. When the upgrade completes you will be prompted to remove the "
+           "USB flash drive and reset your Piksi Multi.\n"
+           "5. Verify that the firmware version has upgraded via inspection "
+           "of the Current Firmware Version box on the Firmware Update Tab "
+           "of the Swift Console.\n")
 
   def _manage_enables(self):
     """ Manages whether traits widgets are enabled in the UI or not. """

--- a/piksi_tools/console/update_view.py
+++ b/piksi_tools/console/update_view.py
@@ -622,14 +622,10 @@ class UpdateView(HasTraits):
       sleep(0.5)
 
       # Check if firmware is out of date and notify user if so.
-      local_stm_version = parse_version(
-          self.settings['system_info']['firmware_version'].value)
-      remote_stm_version = parse_version(self.newest_stm_vers)
+      local_stm_version = self.settings['system_info']['firmware_version'].value
+      remote_stm_version = self.newest_stm_vers
 
       self.fw_outdated = remote_stm_version > local_stm_version
-
-      # Record firmware version reported each time this callback is called.
-      self.last_call_fw_version = local_stm_version
 
       if self.fw_outdated:
         fw_update_prompt = \
@@ -655,7 +651,9 @@ class UpdateView(HasTraits):
 
         fw_update_prompt.run()
 
-      # Check if firmware successfully upgraded and notify user if so.
+      # Check if firmware successfully upgraded and notify user if so. Don't
+      # prompt if firmware is outdated as user has already been prompted about
+      # this.
       if not self.fw_outdated and self.last_call_fw_version is not None and \
           self.last_call_fw_version != local_stm_version:
         success_prompt = \
@@ -664,12 +662,15 @@ class UpdateView(HasTraits):
                                   actions=[prompt.close_button]
                                  )
         success_prompt.text = \
-            "Firmware successfully upgraded.\n\n" + \
+            "Device firmware was successfully upgraded.\n\n" + \
             "Old Firmware :\n\t%s\n\n" % \
                 self.last_call_fw_version + \
             "Current Firmware :\n\t%s\n\n" % \
                 local_stm_version
         success_prompt.run()
+
+    # Record firmware version reported each time this callback is called.
+    self.last_call_fw_version = local_stm_version
 
   def _get_latest_version_info(self):
     """ Get latest firmware / console version from website. """

--- a/piksi_tools/console/update_view.py
+++ b/piksi_tools/console/update_view.py
@@ -652,7 +652,7 @@ class UpdateView(HasTraits):
         fw_update_prompt.run()
 
     # Check if firmware successfully upgraded and notify user if so.
-    if not self.fw_outdated and self.last_call_fw_version is not None and \
+    if self.last_call_fw_version is not None and \
         self.last_call_fw_version != local_stm_version:
       fw_success_str = "Firmware successfully upgraded from %s to %s." % \
                        (self.last_call_fw_version, local_stm_version)

--- a/piksi_tools/console/update_view.py
+++ b/piksi_tools/console/update_view.py
@@ -654,7 +654,7 @@ class UpdateView(HasTraits):
     # Check if firmware successfully upgraded and notify user if so.
     if not self.fw_outdated and self.last_call_fw_version is not None and \
         self.last_call_fw_version != local_stm_version:
-      fw_success_str = "Firmware successfully upgraded from %s to %s." %
+      fw_success_str = "Firmware successfully upgraded from %s to %s." % \
                        (self.last_call_fw_version, local_stm_version)
       print fw_success_str
       self._write(fw_success_str)

--- a/piksi_tools/console/update_view.py
+++ b/piksi_tools/console/update_view.py
@@ -335,7 +335,7 @@ class UpdateView(HasTraits):
     self.serial_upgrade = serial_upgrade
     self.last_call_fw_version = None
     if not self.serial_upgrade:
-      self.stream.write(
+      self._write(
            "1. Insert the USB flash drive provided with your Piki Multi into "
            "your computer.  Select the flash drive root directory as the "
            "firmware download destination using the \"Please "
@@ -654,8 +654,10 @@ class UpdateView(HasTraits):
     # Check if firmware successfully upgraded and notify user if so.
     if not self.fw_outdated and self.last_call_fw_version is not None and \
         self.last_call_fw_version != local_stm_version:
-      print "Firmware successfully upgraded from %s to %s." %
-            (self.last_call_fw_version, local_stm_version)
+      fw_success_str = "Firmware successfully upgraded from %s to %s." %
+                       (self.last_call_fw_version, local_stm_version)
+      print fw_success_str
+      self._write(fw_success_str)
 
     # Record firmware version reported each time this callback is called.
     self.last_call_fw_version = local_stm_version

--- a/piksi_tools/console/update_view.py
+++ b/piksi_tools/console/update_view.py
@@ -208,11 +208,6 @@ class PulsableProgressDialog(ProgressDialog):
       self.max = 100
       GUI.invoke_later(self.update, int(100*float(count)/self.passed_max))
 
-
-
-
-
-
 class UpdateView(HasTraits):
   piksi_hw_rev = String('piksi_multi')
   is_v2 = Bool(False)
@@ -674,7 +669,7 @@ class UpdateView(HasTraits):
                 self.last_call_fw_version + \
             "Current Firmware :\n\t%s\n\n" % \
                 local_stm_version
-        success_prompt.run(block=False)
+        success_prompt.run()
 
   def _get_latest_version_info(self):
     """ Get latest firmware / console version from website. """

--- a/piksi_tools/console/update_view.py
+++ b/piksi_tools/console/update_view.py
@@ -651,23 +651,11 @@ class UpdateView(HasTraits):
 
         fw_update_prompt.run()
 
-      # Check if firmware successfully upgraded and notify user if so. Don't
-      # prompt if firmware is outdated as user has already been prompted about
-      # this.
-      if not self.fw_outdated and self.last_call_fw_version is not None and \
-          self.last_call_fw_version != local_stm_version:
-        success_prompt = \
-            prompt.CallbackPrompt(
-                                  title='Firmware Update Success',
-                                  actions=[prompt.close_button]
-                                 )
-        success_prompt.text = \
-            "Device firmware was successfully upgraded.\n\n" + \
-            "Old Firmware :\n\t%s\n\n" % \
-                self.last_call_fw_version + \
-            "Current Firmware :\n\t%s\n\n" % \
-                local_stm_version
-        success_prompt.run()
+    # Check if firmware successfully upgraded and notify user if so.
+    if not self.fw_outdated and self.last_call_fw_version is not None and \
+        self.last_call_fw_version != local_stm_version:
+      print "Firmware successfully upgraded from %s to %s." %
+            (self.last_call_fw_version, local_stm_version)
 
     # Record firmware version reported each time this callback is called.
     self.last_call_fw_version = local_stm_version


### PR DESCRIPTION
Make instructions more clear and add a console print upon firmware version change.

`parse_version` was just returning None on firmware strings so I removed it. Now firmware version checking and firmware update nagging window works properly.

@denniszollo 