### PR TITLE
Skylark debug

### DIFF
--- a/piksi_tools/console/sbp_relay_view.py
+++ b/piksi_tools/console/sbp_relay_view.py
@@ -108,9 +108,14 @@ class SkylarkWatchdogThread(threading.Thread):
   def stop(self):
     """ stops thread, sets _stop event"""
     self._stop.set()
-    if self.stopped_callback:
-       self.stopped_callback()
     self._stop_time = time.time()
+    if self.stopped_callback:
+      try:
+        self.stopped_callback()
+      except:
+        print "Error stopping SkylarkWatchdogThread: User supplied callback has unhandeled exception") 
+        import traceback
+        print traceback.format_exc()        
     if self.verbose:
       print ("SkylarkWatchdogThread initialized "
              "at {0} and connected since {1} stopped at {2}").format(


### PR DESCRIPTION
@jkretzmer @mookerji 

This combined with the write lock on the sbp serial driver is working well for me on the bench.   Please  review if you are able.  Stefan is going to drive this console tomorrow to see if it improves the situation.

Some things to note since you last looked at it.

There is a console command line option to give a yaml string to the skylark view to pre-populate fields in the sbp_relay_view constructor:

That command line options would look like this:
 --skylark  "{'rover_pragma':'trace','rover_uuid':'46f553a3-a0c8-460f-ad3a-f2291d72e6c2', 'verbose':'True'}"

There is also a console command line option to log all stdout/stderr from console to a file: 

  --log-console         Log console stdout/err to file.

The "verbose" option with the --log-console would be intended to help us during drives to get to the bottom of any console skylark issues.