### PR TITLE
Skylark catch exceptions

### DIFF
--- a/piksi_tools/console/sbp_relay_view.py
+++ b/piksi_tools/console/sbp_relay_view.py
@@ -215,9 +215,18 @@ class SkylarkWatchdogThread(threading.Thread):
     """ Continuously try and reconnect until thread stopped by other means """
     while not self.stopped():
       print "Attempting to connect to skylark..."
-      ret = self.connect(self.link, self.skylark_config)
-      if self.verbose:
-        "Returned from SkylarkWatchdogThread.connect with code {0}".format(ret)
+      try:
+        ret = self.connect(self.link, self.skylark_config)
+        if self.verbose:
+          "Returned from SkylarkWatchdogThread.connect with code {0}".format(ret)
+      except UserWarning as w:
+        print "UserWarning exception received from SkylarkWatchdogThread.connect"
+        import traceback
+        print traceback.format_exc()
+      except:
+        print "Unspecified exception received from SkylarkWatchdogThread.connect"
+        import traceback
+        print traceback.format_exc()
       time.sleep(0.25)
       print "Network Observation Stream Disconnected."
 


### PR DESCRIPTION
During today's drive, we saw the following behavior:

`Jan 30 2017 08:02:03,-1,SkylarkWatchdogThread connection attempted at time 1485792123.52 with parameters link: <sbp.client.handler.Handler object at 0x07BF58D0>, skylark_url http://broker.staging.skylark.swiftnav.com, device_uid: 3071B373-1847-4183-9478-9DB713010681, whitelist None, rover pragma: proxy, base_pragma: , rover_uuid: 3071B373-1847-4183-9478-9DB713010681, base_uuid 3071B373-1847-4183-9478-9DB713010681
Jan 30 2017 08:02:04,-1,Attempting to read observation from Skylark...
Jan 30 2017 08:06:41,-1,c:\PROGRA~2\SWIFTN~1\SWIFTC~1\sbp\client\drivers\network_drivers.py:281: UserWarning: Client connection error to http://broker.staging.skylark.swiftnav.com with [GET] headers {'Device-Uid': '3071B373-1847-4183-9478-9DB713010681', 'Accept': 'application/vnd.swiftnav.broker.v1+sbp2', 'Pragma': 'proxy'}: msg=HTTPConnectionPool(host='broker.staging.skylark.swiftnav.com', port=80): Max retries exceeded with url: / (Caused by ReadTimeoutError("HTTPConnectionPool(host='broker.staging.skylark.swiftnav.com', port=80): Read timed out. (read timeout=10)",))
`

which came from this line in the code https://github.com/swift-nav/piksi_tools/blob/master/piksi_tools/console/sbp_relay_view.py#L438

After this happened skylark disconnected in the console (confirmed by log and Stefan's observation).

I had assumed that "warnings.warn" in the network driver here https://github.com/swift-nav/libsbp/blob/master/python/sbp/client/drivers/network_drivers.py#L293

would not throw an exception, but it appears python is configured in the console such that UserWarnings are exceptions.

This change should make sure that a skylark connection is re-attempted no matter what happens in the network driver or requests.

/cc @mookerji @JoshuaGross @switanis @jkretzmer 

Can I get someone to take a look and agree that catching all exceptions is warranted here to ensure reconnection attempt?