### PR TITLE
console.py Fix certificate paths when outside of Pyinstaller bundle.

### DIFF
--- a/piksi_tools/console/console.py
+++ b/piksi_tools/console/console.py
@@ -15,8 +15,6 @@ import sbp.client as sbpc
 import signal
 import sys
 
-os.environ['REQUESTS_CA_BUNDLE'] = 'cacert.pem'
-
 import math
 import numpy as np
 import datetime
@@ -126,6 +124,8 @@ from threading import Thread, Event
 
 basedir = determine_path()
 icon = ImageResource('icon', search_path=['images', os.path.join(basedir, 'images')])
+
+os.environ['REQUESTS_CA_BUNDLE'] = os.path.join(basedir, 'cacert.pem')
 
 from piksi_tools.console.tracking_view import TrackingView
 from piksi_tools.console.solution_view import SolutionView


### PR DESCRIPTION
this fixes https connection issue below when running from source.

/usr/local/lib/python2.7/site-packages/sbp/client/drivers/network_drivers.py:281: UserWarning: Client connection error to XX with [GET] headers {'Device-Uid': '19BA76E1-35A6-4CA6-8480-408A502ADCC4', 'Accept': 'application/vnd.swiftnav.broker.v1+sbp2'}: msg=[Errno 2] No such file or directory
 warnings.warn(msg)