### PR TITLE
Adding Klobuchar correction disabler in settings

### DIFF
--- a/piksi_tools/console/settings.yaml
+++ b/piksi_tools/console/settings.yaml
@@ -348,6 +348,16 @@
     rover and represents the inverse tangent of the north and east components of the baseline
   Notes: No smoothing or additional processing is provided to improve heading output.
 
+  - group: solution
+  name: disable_klobuchar_correction
+  type: boolean
+  expert: true
+  units:
+  default value: False
+  enumerated possible values: True,False
+  Description: Disable Klobuchar ionospheric corrections
+  Notes: If True, Klobuchar ionospheric corrections will not be applied.
+
 - group: system_info
   name: serial_number
   type: integer


### PR DESCRIPTION
The Klobuchar corrections are going to be enabled in the filter for v1.1 release, see https://github.com/swift-nav/piksi_firmware_private/pull/599.
This PR adds an advanced setting in the console to disable the application of Klobuchar correction.
