### PR TITLE
Fix heading offset descriptor to specify we subtract the offset value…

### DIFF
--- a/piksi_tools/console/settings.yaml
+++ b/piksi_tools/console/settings.yaml
@@ -364,7 +364,7 @@
   enumerated possible values: N/A
   Description: Rotate the heading output
   Notes: | 
-    Adds an offset to the heading output to rotate the heading vector to align the
+    Subtracts an offset to the heading output to rotate the heading vector to align the
     baseline heading with a desired 0 heading. Valid values are -180.0 to 180.0 degrees
 
 - group: solution


### PR DESCRIPTION
…, not add

@dzollo change the description on the heading offset to indicate we're subtracting the offset back to the 0 heading