### PR TITLE
Move some download links to https.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Console example
 
 To use the Piksi console, binary installers (Windows and OS X) are here_.
 
-.. _here: http://downloads.swiftnav.com/piksi_console/
+.. _here: https://s3-us-west-1.amazonaws.com/downloads.swiftnav.com/piksi_console/
 
 Testing
 -------

--- a/piksi_tools/console/update_downloader.py
+++ b/piksi_tools/console/update_downloader.py
@@ -14,7 +14,7 @@ from json import load as jsonload
 from urlparse import urlparse
 import os
 
-INDEX_URL = 'http://downloads.swiftnav.com/index.json'
+INDEX_URL = 'https://s3-us-west-1.amazonaws.com/downloads.swiftnav.com/index.json'
 
 class UpdateDownloader:
 

--- a/piksi_tools/console/update_view.py
+++ b/piksi_tools/console/update_view.py
@@ -42,7 +42,7 @@ else:
 icon = ImageResource('icon',
          search_path=['images', os.path.join(basedir, 'images')])
 
-INDEX_URL = 'http://downloads.swiftnav.com/index.json'
+INDEX_URL = 'https://s3-us-west-1.amazonaws.com/downloads.swiftnav.com/index.json'
 HT = 8
 COLUMN_WIDTH = 100
 
@@ -476,7 +476,7 @@ class UpdateView(HasTraits):
             "Your Piksi Console is out of date and may be incompatible\n" + \
             "with current firmware. We highly recommend upgrading to\n" + \
             "ensure proper behavior.\n\n" + \
-            "Please visit http://downloads.swiftnav.com to\n" + \
+            "Please visit https://s3-us-west-1.amazonaws.com/downloads.swiftnav.com/index.json to\n" + \
             "download the newest version.\n\n" + \
             "Local Console Version :\n\t" + \
                 CONSOLE_VERSION + \

--- a/piksi_tools/testing/run_bootloader_tests.sh
+++ b/piksi_tools/testing/run_bootloader_tests.sh
@@ -64,9 +64,9 @@ declare -a nap=(
 )
 
 # URL prefixes for firmwares.
-BTLDR_PREFIX="http://downloads.swiftnav.com/piksi_v2.3.1/bootloader"
-FW_PREFIX="http://downloads.swiftnav.com/piksi_v2.3.1/stm_fw"
-NAP_PREFIX="http://downloads.swiftnav.com/piksi_v2.3.1/nap_fw"
+BTLDR_PREFIX="https://s3-us-west-1.amazonaws.com/downloads.swiftnav.com/piksi_v2.3.1/bootloader"
+FW_PREFIX="https://s3-us-west-1.amazonaws.com/downloads.swiftnav.com/piksi_v2.3.1/stm_fw"
+NAP_PREFIX="https://s3-us-west-1.amazonaws.com/downloads.swiftnav.com/piksi_v2.3.1/nap_fw"
 
 # Download firmware files.
 for i in "${btldr[@]}"
@@ -81,4 +81,3 @@ for i in "${nap[@]}"
 do
    $DOWNLOAD $NAP_PREFIX"/$i"
 done
-


### PR DESCRIPTION
This should be done more formally by enforcing `https` on `downloads.swiftnav.com`.