### PR TITLE
Sbp_relay_view: remove skylark labels, rename variables, remove visib…

### DIFF
--- a/piksi_tools/console/console.py
+++ b/piksi_tools/console/console.py
@@ -552,7 +552,7 @@ class SwiftConsole(HasTraits):
           networking_dict = yaml.load(networking)
           networking_dict.update({'show_networking':True})
         except yaml.YAMLError:
-          print "Unable to interpret Skylark cmdline argument.  It will be ignored."
+          print "Unable to interpret networking cmdline argument.  It will be ignored."
           import traceback
           print traceback.format_exc()
           networking_dict = {'show_networking':True}

--- a/piksi_tools/console/console.py
+++ b/piksi_tools/console/console.py
@@ -22,7 +22,7 @@ import time
 
 
 from os.path import expanduser
-from piksi_tools.serial_link import swriter, get_uuid, DEFAULT_BASE
+from piksi_tools.serial_link import swriter, get_uuid
 from piksi_tools.version import VERSION as CONSOLE_VERSION
 from piksi_tools.heartbeat import Heartbeat
 from sbp.client.drivers.pyftdi_driver import PyFTDIDriver
@@ -65,8 +65,8 @@ def get_args():
                       help="Do not swallow exceptions.")
   parser.add_argument('--log-console', action='store_true',
                       help="Log console stdout/err to file.")
-  parser.add_argument('--skylark', default='',
-                      help="key value pairs to pass to sbp_relay_view initializer for skylark")
+  parser.add_argument('--networking', default=None, const='{}', nargs='?',
+                      help="key value pairs to pass to sbp_relay_view initializer for network")
   parser.add_argument('--serial-upgrade', action='store_true',
                       help="Allow software upgrade over serial.")
   parser.add_argument('-h', '--help', action='store_true',
@@ -499,7 +499,7 @@ class SwiftConsole(HasTraits):
   
   def __init__(self, link, update, log_level_filter, skip_settings=False, error=False, 
                cnx_desc=None, json_logging=False, log_dirname=None, override_filename=None, 
-               log_console=False, skylark="", serial_upgrade=False):
+               log_console=False, networking=None, serial_upgrade=False):
     self.error = error
     self.cnx_desc = cnx_desc
     self.dev_id = cnx_desc
@@ -546,19 +546,20 @@ class SwiftConsole(HasTraits):
       self.update_view = UpdateView(self.link, download_dir=swift_path, prompt=update, serial_upgrade=serial_upgrade)
       self.imu_view = IMUView(self.link)
       settings_read_finished_functions.append(self.update_view.compare_versions)
-      if skylark:
+      if networking:
         import yaml
         try:
-          skylark_dict = yaml.load(skylark)
+          networking_dict = yaml.load(networking)
+          networking_dict.update({'show_networking':True})
         except yaml.YAMLError:
           print "Unable to interpret Skylark cmdline argument.  It will be ignored."
           import traceback
           print traceback.format_exc()
-          skylark_dict = {}
+          networking_dict = {'show_networking':True}
       else:
-        skylark_dict = {}
-      skylark_dict.update({'whitelist':[SBP_MSG_POS_LLH, SBP_MSG_HEARTBEAT]})
-      self.networking_view = SbpRelayView(self.link, **skylark_dict)
+        networking_dict = {}
+      networking_dict.update({'whitelist':[SBP_MSG_POS_LLH, SBP_MSG_HEARTBEAT]})
+      self.networking_view = SbpRelayView(self.link, **networking_dict)
       self.json_logging = json_logging
       self.csv_logging = False
       self.first_json_press = True
@@ -755,7 +756,7 @@ with selected_driver as driver:
       log_filter = args.initloglevel[0]
     with SwiftConsole(link, args.update, log_filter, cnx_desc=connection_description, error=args.error, 
                  json_logging=args.log, log_dirname=args.log_dirname, override_filename=args.logfilename,
-                 log_console=args.log_console, skylark=args.skylark, 
+                 log_console=args.log_console, networking=args.networking, 
                  serial_upgrade=args.serial_upgrade) as console: 
       console.configure_traits()
 

--- a/piksi_tools/serial_link.py
+++ b/piksi_tools/serial_link.py
@@ -37,7 +37,7 @@ from piksi_tools.utils import mkdir_p
 SERIAL_PORT  = "/dev/ttyUSB0"
 SERIAL_BAUD  = 115200
 CHANNEL_UUID = '118db405-b5de-4a05-87b5-605cc85af924'
-DEFAULT_BASE = "http://broker.staging.skylark.swiftnav.com"
+DEFAULT_BASE = "https://broker.skylark2.swiftnav.com"
 
 def logfilename():
   return time.strftime("serial-link-%Y%m%d-%H%M%S.log.json") 


### PR DESCRIPTION
…le default URL

This pull requests is intended as an alternative to #545

Rather than disabling forever, this disables the http connection view by default.  If  a  --networking command line argument is passed to the console, then the view shows up as before.  Optionally, a dictionary can be supplied as an argument to the --networking command line argument which can set any keyword args in the gui element constructor.  In this way we retain the current networking feature from a internet connect PC over serial for testing and demos but avoid confusing our users.   I agree that this code is over-complicated.

Additional notes:
- skylark branding vanquished from UI and variable names
- old "--skylark" command line option is now "--networking"
- old "base" dictionary key is now the more useful "url" key
- when no url is specified, it will default to the new skylark 2 broker
- this will pave the way for a console ntrip client someday in the future along with a refactor of this mess.

Testing:
* bench tested by DZ

/cc @mfine @switanis @mookerji 