### PR TITLE
Remove kiwisolver, update deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-numpy==1.12.1
+numpy==1.13.0
 cython==0.25.2
-pytest==3.1.1
+pytest==3.1.2
 tox==2.7.0
 futures==3.1.1
 pep8==1.7.0
@@ -9,6 +9,6 @@ pyserial==3.3
 pylibftdi==0.15.0
 pyparsing==2.2.0
 pygments==2.2.0
-requests==2.17.3
+requests==2.18.1
 six==1.10.0
 sbp==2.2.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,5 @@ pylibftdi==0.15.0
 pyparsing==2.2.0
 pygments==2.2.0
 requests==2.17.3
-kiwisolver==0.1.3
 six==1.10.0
 sbp==2.2.6

--- a/requirements_gui.txt
+++ b/requirements_gui.txt
@@ -1,5 +1,5 @@
 chaco==4.6.1
-enable==4.6.1
+enable==4.6.2
 traits==4.6.0 
 traitsui==5.1.0 
 pyface==5.1.0 


### PR DESCRIPTION
kiwisolver causes build issues for us currently. I noticed that we're not even using it(it is an optional dependency of enable, and we are not using any features which require kiwisolver).