### PR TITLE
Add GLONASS configuration parameters in the console

### DIFF
--- a/piksi_tools/console/settings.yaml
+++ b/piksi_tools/console/settings.yaml
@@ -425,6 +425,16 @@
   Description: Disable Klobuchar ionospheric corrections
   Notes: If True, Klobuchar ionospheric corrections will not be applied.
 
+- group: solution
+  name: enable_glonass_in_pvt
+  expert: true
+  type: boolean
+  units: N/A
+  default value: 
+  enumerated possible values: True,False
+  Description: Enable GLONASS measurement processing in navigation filter
+  Notes: If set to True, GLONASS measurements are processed in the navigation filter.
+
 - group: system_info
   name: serial_number
   expert: False
@@ -762,6 +772,16 @@
   Description: Tracking elevation mask
   Notes: Satellites must be above the horizon by at least this angle before they
     will be tracked.
+
+- group: solution
+  name: glonass_measurement_std_downweight_factor
+  expert: true
+  type: float
+  units: N/A
+  default value: N/A
+  enumerated possible values:
+  Description: Down weights GLONASS measurements by a given factor in the navigation filter 
+  Notes: This parameter down weights GLONASS observations relative to GPS observations by this factor.
 
 - group: track
   name: send_trk_detailed


### PR DESCRIPTION
This PR adds the description of two GLONASS parameters that will be accessible from the console:
- Enable the processing of GLONASS measurements within the filter (otherwise, measurements are generated but unused)
- Introduce the possibility to downweight GLONASS measurements versus GPS measurements from the console

@jck @denniszollo 
cc: @anth-cole
Associated PR:
https://github.com/swift-nav/libswiftnav-private/pull/810
https://github.com/swift-nav/piksi_firmware_private/pull/942/files