### PR TITLE
observation_view: restore total obs count

### DIFF
--- a/piksi_tools/console/observation_view.py
+++ b/piksi_tools/console/observation_view.py
@@ -103,6 +103,7 @@ class ObservationView(CodeFiltered):
                 show_border=True))
 
     def update_obs(self):
+        self.obs_count = len(self.obs)
         self._obs_table_list = [
             ('{} ({})'.format(svid[0], code_to_str(svid[1])), ) + obs
             for svid, obs in sorted(self.obs.items())


### PR DESCRIPTION
We lost the total obs count when adding glonass
/cc @jck 

WIthout this PR the value is always 0:
<img width="1032" alt="screen shot 2017-09-12 at 9 16 30 pm" src="https://user-images.githubusercontent.com/11276774/30359467-c2673476-97ff-11e7-81eb-974e46255eb5.png">
