### PR TITLE
Make window narrower

### DIFF
--- a/piksi_tools/console/imu_view.py
+++ b/piksi_tools/console/imu_view.py
@@ -51,13 +51,16 @@ class IMUView(HasTraits):
             Item(
                 'plot',
                 editor=ComponentEditor(bgcolor=(0.8, 0.8, 0.8)),
-                show_label=False, ),
+                show_label=False),
             HGroup(
-                Item('imu_temp', format_str='%.2f C'),
-                Item('imu_conf', format_str='0x%02X'),
-                Item('rms_acc_x', format_str='%.2f g'),
-                Item('rms_acc_y', format_str='%.2f g'),
-                Item('rms_acc_z', format_str='%.2f g'), ), ))
+                Item('imu_temp',  format_str='%.2f C', height=-16, width=4),
+                Item('imu_conf',  format_str='0x%02X', height=-16, width=4),
+                Item('rms_acc_x', format_str='%.2f g', height=-16, width=4),
+                Item('rms_acc_y', format_str='%.2f g', height=-16, width=4),
+                Item('rms_acc_z', format_str='%.2f g', height=-16, width=4),
+            ),
+        )
+    )
 
     def imu_set_data(self):
         self.plot_data.set_data('acc_x', self.acc[:, 0])

--- a/piksi_tools/console/imu_view.py
+++ b/piksi_tools/console/imu_view.py
@@ -53,8 +53,8 @@ class IMUView(HasTraits):
                 editor=ComponentEditor(bgcolor=(0.8, 0.8, 0.8)),
                 show_label=False),
             HGroup(
-                Item('imu_temp',  format_str='%.2f C', height=-16, width=4),
-                Item('imu_conf',  format_str='0x%02X', height=-16, width=4),
+                Item('imu_temp', format_str='%.2f C', height=-16, width=4),
+                Item('imu_conf', format_str='0x%02X', height=-16, width=4),
                 Item('rms_acc_x', format_str='%.2f g', height=-16, width=4),
                 Item('rms_acc_y', format_str='%.2f g', height=-16, width=4),
                 Item('rms_acc_z', format_str='%.2f g', height=-16, width=4),
@@ -72,7 +72,7 @@ class IMUView(HasTraits):
 
     def imu_aux_callback(self, sbp_msg, **metadata):
         if sbp_msg.imu_type == 0:
-            self.imu_temp = 23 + sbp_msg.temp / 2.**9
+            self.imu_temp = 23 + sbp_msg.temp / 2. ** 9
             self.imu_conf = sbp_msg.imu_conf
         else:
             print("IMU type %d not known" % sbp_msg.imu_type)
@@ -85,7 +85,7 @@ class IMUView(HasTraits):
 
         if self.imu_conf is not None:
             acc_range = self.imu_conf & 0xF
-            sf = 2.**(acc_range + 1) / 2.**15
+            sf = 2. ** (acc_range + 1) / 2. ** 15
             self.rms_acc_x = sf * np.sqrt(np.mean(np.square(self.acc[:, 0])))
             self.rms_acc_y = sf * np.sqrt(np.mean(np.square(self.acc[:, 1])))
             self.rms_acc_z = sf * np.sqrt(np.mean(np.square(self.acc[:, 2])))

--- a/piksi_tools/console/spectrum_analyzer_view.py
+++ b/piksi_tools/console/spectrum_analyzer_view.py
@@ -17,7 +17,7 @@ from enable.api import ComponentEditor
 from pyface.api import GUI
 from sbp.piksi import SBP_MSG_SPECAN, MsgSpecan
 from traits.api import Dict, HasTraits, Instance, Str
-from traitsui.api import CheckListEditor, Item, View
+from traitsui.api import EnumEditor, Item, View, HGroup, Spring
 
 # How many points are in each FFT?
 NUM_POINTS = 512
@@ -62,16 +62,27 @@ class SpectrumAnalyzerView(HasTraits):
     plot = Instance(Plot)
     plot_data = Instance(ArrayPlotData)
     which_plot = Str("Channel 1")
+    hint = Str("Enable with setting in \"System Monitor\" group.")
     traits_view = View(
         Item(
             'plot',
             editor=ComponentEditor(bgcolor=(0.8, 0.8, 0.8)),
             show_label=False),
-        Item(
-            name='which_plot',
-            show_label=False,
-            editor=CheckListEditor(
-                values=["Channel 1", "Channel 2", "Channel 3", "Channel 4"])))
+        HGroup(
+            Spring(width=20, springy=False),
+            Item(
+                '',
+                label='Channel Selection:',
+                emphasized=True),
+            Item(
+                name='which_plot',
+                show_label=False,
+                tooltip='Select the RF Channel for which to display Spectrum Analyzer',
+                editor=EnumEditor(
+                    values=["Channel 1", "Channel 2", "Channel 3", "Channel 4"])),
+            Spring(width=20, springy=True),
+            Item('hint', show_label=False, style='readonly', style_sheet='*{font-style:italic}'),
+            Spring(width=20, springy=True)))
 
     def parse_payload(self, raw_payload):
         """
@@ -222,6 +233,7 @@ class SpectrumAnalyzerView(HasTraits):
         self.plot.title_color = [0, 0, 0.43]
 
         self.plot.value_axis.orientation = 'right'
+        self.plot.value_axis.title_spacing = 30
         self.plot.value_axis.title = 'Amplitude (dB)'
 
         self.plot.index_axis.title = 'Frequency (MHz)'


### PR DESCRIPTION
This PR adds a few visual tweaks to the console.

/cc @jck

First, it reduces the minimum window size with the goal of enabling side by side consoles on a typical laptop screen.  See diagram below
<img width="1033" alt="screen shot 2017-09-12 at 9 06 03 pm" src="https://user-images.githubusercontent.com/11276774/30359325-d8365422-97fe-11e7-87fd-32d8ddcb989e.png">


Second, this adds a quick hint to the Spectrum Analyzer View to tell people how to enable it and resizes the view so that the "Amplitude" label is not cut off. See the two screenshots below.

With this PR:
![image](https://user-images.githubusercontent.com/11276774/30359371-16ca8e4c-97ff-11e7-9eb3-379940ab3db8.png)

Without this PR:
![image](https://user-images.githubusercontent.com/11276774/30359376-20e2287c-97ff-11e7-9d2e-9d2c3073d95b.png)


Notes:
Please ignore the missing PNG icons from the screenshots - these will be correct when built with the CI system.  