### PR TITLE
settings_view.py: Change revert timeout from 1 second to 5 second

### DIFF
--- a/piksi_tools/console/settings_view.py
+++ b/piksi_tools/console/settings_view.py
@@ -34,6 +34,8 @@ from piksi_tools.console.gui_utils import MultilineTextEditor
 from .settings_list import SettingsList
 from .utils import resource_filename
 
+SETTINGS_REVERT_TIMEOUT = 5
+
 if ETSConfig.toolkit != 'null':
     from enable.savage.trait_defs.ui.svg_button import SVGButton
 else:
@@ -124,7 +126,7 @@ class Setting(SettingBase):
                 self.value = self.value.encode('ascii', 'replace')
             if not self.revert_in_progress:
                 self.timed_revert_thread = threading.Thread(
-                    target=self.revert_after_delay, args=(1, name, old, new))
+                    target=self.revert_after_delay, args=(SETTINGS_REVERT_TIMEOUT, name, old, new))
                 self.settings.set(self.section, self.name, self.value)
                 self.timed_revert_thread.start()
             self.revert_in_progress = False


### PR DESCRIPTION
Before this PR, changing the Ethernet Port mode to DHCP resulted in the console complaining that it was unable to change the setting.  After this PR, I expect that to go away in most cases.

Testing:  

Tested changing the ethernet setting on the bench, no issues.  Tested changing other setting on the bench, no issues.