### PR TITLE
serial_link: re-add osx fix to use file rather than CDC driver over usb

### DIFF
--- a/piksi_tools/serial_link.py
+++ b/piksi_tools/serial_link.py
@@ -170,7 +170,7 @@ def get_driver(use_ftdi=False,
     # HACK - if we are on OSX and the device appears to be a CDC device, open as a binary file
         for each in serial.tools.list_ports.comports():
             if port == each[0]:
-                if each[1].startswith("Gadget Serial"):
+                if each[1].startswith("Gadget Serial") or each[1].startswith("Piksi"):
                     print("opening a file driver")
                     return CdcDriver(open(port, 'w+b', 0))
         return PySerialDriver(port, baud, rtscts=rtscts)


### PR DESCRIPTION
I was able to reproduce the bug where Pyserial opened a garbage serial port for the CDC driver with no data on osx Yosemite.  Since we changed the device ID and Vendor ID for Piksi, we were no longer hitting the code path hack we put in for the v1.0 release.  This minor fix puts us back on the code path to use the file driver rather than whatever pyserial wants to use that isn't reliable.

Testing:
tested extensively on OSX over usb

TODO:
Needs testing on Linux and Windows over USB
we may need to add platform aware logic to get this right

@switanis  when you go to execute the USB on windows test in testlink I'll need to provide you this Appveyor build to test as well as the rc3 console.