### PR TITLE
console.py:PortChooser: config enter for ok button

### DIFF
--- a/piksi_tools/console/console.py
+++ b/piksi_tools/console/console.py
@@ -757,7 +757,6 @@ class ShowUsage(HasTraits):
 flow_control_options_list = ['None', 'Hardware RTS/CTS']
 cnx_type_list = ['Serial/USB', 'TCP/IP']
 
-
 class PortChooser(HasTraits):
     port = Str(None)
     ports = List()
@@ -825,6 +824,7 @@ class PortChooser(HasTraits):
                 Spring(),
                 visible_when="mode==\'TCP/IP\'"), ),
         buttons=['OK', 'Cancel'],
+        default_button = 'OK',
         close_result=False,
         icon=icon,
         width=400,

--- a/piksi_tools/console/console.py
+++ b/piksi_tools/console/console.py
@@ -144,7 +144,7 @@ class ConsoleHandler(Handler):
         """
         if info.initialized:
             info.ui.title = info.object.dev_id + \
-                "(" + info.object.device_serial + ") " + CONSOLE_TITLE
+                            "(" + info.object.device_serial + ") " + CONSOLE_TITLE
 
 
 class SwiftConsole(HasTraits):
@@ -757,6 +757,7 @@ class ShowUsage(HasTraits):
 flow_control_options_list = ['None', 'Hardware RTS/CTS']
 cnx_type_list = ['Serial/USB', 'TCP/IP']
 
+
 class PortChooser(HasTraits):
     port = Str(None)
     ports = List()
@@ -824,7 +825,7 @@ class PortChooser(HasTraits):
                 Spring(),
                 visible_when="mode==\'TCP/IP\'"), ),
         buttons=['OK', 'Cancel'],
-        default_button = 'OK',
+        default_button='OK',
         close_result=False,
         icon=icon,
         width=400,
@@ -852,7 +853,6 @@ class PortChooser(HasTraits):
 
 
 def main():
-
     warnings.simplefilter(action="ignore", category=FutureWarning)
     logging.basicConfig()
     args = None

--- a/piksi_tools/console/console.py
+++ b/piksi_tools/console/console.py
@@ -144,7 +144,7 @@ class ConsoleHandler(Handler):
         """
         if info.initialized:
             info.ui.title = info.object.dev_id + \
-                            "(" + info.object.device_serial + ") " + CONSOLE_TITLE
+                "(" + info.object.device_serial + ") " + CONSOLE_TITLE
 
 
 class SwiftConsole(HasTraits):


### PR DESCRIPTION
Now when you press enter in the initial port chooser pop-up it presses OK for you.