### PR TITLE
Add Skylark tab and show serial number and UUID in main window.

### DIFF
--- a/piksi_tools/console/console.py
+++ b/piksi_tools/console/console.py
@@ -191,6 +191,7 @@ class SwiftConsole(HasTraits):
     num_sats = Int(0)
     cnx_desc = Str('')
     latency = Str('')
+    uuid = Str('')
     directory_name = Directory
     json_logging = Bool(True)
     csv_logging = Bool(False)
@@ -356,6 +357,16 @@ class SwiftConsole(HasTraits):
                     ),
                     Item(
                         'latency',
+                        padding=2,
+                        show_label=False,
+                        style='readonly'),
+                    Item(
+                        '',
+                        label='Device UUID:',
+                        emphasized=True,
+                        tooltip='Corrections latency (-1 means no corrections)'
+                    ),                    Item(
+                        'uuid',
                         padding=2,
                         show_label=False,
                         style='readonly'),
@@ -683,10 +694,9 @@ class SwiftConsole(HasTraits):
             # by the networking view.
 
             def update_serial():
-                uuid = None
                 mfg_id = None
                 try:
-                    uuid = self.settings_view.settings['system_info'][
+                    self.uuid = self.settings_view.settings['system_info'][
                         'uuid'].value
                     mfg_id = self.settings_view.settings['system_info'][
                         'serial_number'].value
@@ -694,8 +704,8 @@ class SwiftConsole(HasTraits):
                     pass
                 if mfg_id:
                     self.device_serial = 'PK' + str(mfg_id)
-                self.skylark_view.set_uuid(uuid)
-                self.networking_view.set_route(uuid=uuid, serial_id=mfg_id)
+                self.skylark_view.set_uuid(self.uuid)
+                self.networking_view.set_route(uuid=self.uuid, serial_id=mfg_id)
                 if self.networking_view.connect_when_uuid_received:
                     self.networking_view._connect_rover_fired()
 

--- a/piksi_tools/console/console.py
+++ b/piksi_tools/console/console.py
@@ -58,7 +58,7 @@ from piksi_tools.console.update_view import UpdateView
 from piksi_tools.console.utils import (EMPTY_STR, call_repeatedly,
                                        get_mode, mode_dict, resource_filename,
                                        icon, swift_path)
-
+from piksi_tools.console.skylark_view import SkylarkView
 
 class ArgumentParserError(Exception):
     pass
@@ -175,6 +175,7 @@ class SwiftConsole(HasTraits):
     imu_view = Instance(IMUView)
     mag_view = Instance(MagView)
     spectrum_analyzer_view = Instance(SpectrumAnalyzerView)
+    skylark_view = Instance(SkylarkView)
     log_level_filter = Enum(list(SYSLOG_LEVELS.itervalues()))
     """"
   mode : baseline and solution view - SPP, Fixed or Float
@@ -267,6 +268,7 @@ class SwiftConsole(HasTraits):
                         style='custom'),
                     label='Advanced',
                     show_labels=False),
+                Item('skylark_view', style='custom', label='Skylark'),
                 show_labels=False),
             VGroup(
                 VGroup(
@@ -665,6 +667,7 @@ class SwiftConsole(HasTraits):
                 'whitelist': [SBP_MSG_POS_LLH, SBP_MSG_HEARTBEAT]
             })
             self.networking_view = SbpRelayView(self.link, **networking_dict)
+            self.skylark_view = SkylarkView()
             self.json_logging = json_logging
             self.csv_logging = False
             self.first_json_press = True
@@ -691,6 +694,7 @@ class SwiftConsole(HasTraits):
                     pass
                 if mfg_id:
                     self.device_serial = 'PK' + str(mfg_id)
+                self.skylark_view.set_uuid(uuid)
                 self.networking_view.set_route(uuid=uuid, serial_id=mfg_id)
                 if self.networking_view.connect_when_uuid_received:
                     self.networking_view._connect_rover_fired()

--- a/piksi_tools/console/console.py
+++ b/piksi_tools/console/console.py
@@ -60,6 +60,7 @@ from piksi_tools.console.utils import (EMPTY_STR, call_repeatedly,
                                        icon, swift_path)
 from piksi_tools.console.skylark_view import SkylarkView
 
+
 class ArgumentParserError(Exception):
     pass
 
@@ -365,7 +366,7 @@ class SwiftConsole(HasTraits):
                         label='Device UUID:',
                         emphasized=True,
                         tooltip='Corrections latency (-1 means no corrections)'
-                    ),                    Item(
+                    ), Item(
                         'uuid',
                         padding=2,
                         show_label=False,

--- a/piksi_tools/console/console.py
+++ b/piksi_tools/console/console.py
@@ -690,7 +690,7 @@ class SwiftConsole(HasTraits):
                 except KeyError:
                     pass
                 if mfg_id:
-                    self.device_serial = 'PK' + str(mfg_id)[-6:]
+                    self.device_serial = 'PK' + str(mfg_id)
                 self.networking_view.set_route(uuid=uuid, serial_id=mfg_id)
                 if self.networking_view.connect_when_uuid_received:
                     self.networking_view._connect_rover_fired()

--- a/piksi_tools/console/skylark_view.py
+++ b/piksi_tools/console/skylark_view.py
@@ -24,8 +24,8 @@ SKYLARK_URL = 'https://swiftnav.com/skylark'
 class SkylarkView(HasTraits):
     information = String(
         "Skylark is Swift Navigation's high accuracy GNSS corrections service, "
-        "delivered over the internet. It removes the need for a base station, "
-        "CORS station, or VRS station.")
+        "delivered over the internet. It removes the need for a base station "
+        "or CORS station.")
     link = Button(SKYLARK_URL)
     uuid = String()
 

--- a/piksi_tools/console/skylark_view.py
+++ b/piksi_tools/console/skylark_view.py
@@ -9,20 +9,18 @@
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 
-from traits.api import Bool, Button, Enum, HasTraits, Int, String
-from traitsui.api import (HGroup, Item, Spring, TextEditor, UItem, VGroup,
-                          View, spring)
-from enable.savage.trait_defs.ui.svg_button import SVGButton
+from traits.api import Button, HasTraits, String
+from traitsui.api import (HGroup, Item, TextEditor, VGroup, View, spring)
 
 from piksi_tools.console.gui_utils import MultilineTextEditor
-from piksi_tools.console.utils import (EMPTY_STR, call_repeatedly,
-                                       get_mode, mode_dict, resource_filename,
-                                       icon, swift_path)
+
 import webbrowser
 import threading
 import time
 
 SKYLARK_URL = 'https://swiftnav.com/skylark'
+
+
 class SkylarkView(HasTraits):
     information = String(
         "Skylark is Swift Navigation's high accuracy GNSS corrections service, "

--- a/piksi_tools/console/skylark_view.py
+++ b/piksi_tools/console/skylark_view.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+# Copyright (C) 2018 Swift Navigation Inc.
+# Contact: <dev@swift-nav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+from traits.api import Bool, Button, Enum, HasTraits, Int, String
+from traitsui.api import (HGroup, Item, Spring, TextEditor, UItem, VGroup,
+                          View, spring)
+from enable.savage.trait_defs.ui.svg_button import SVGButton
+
+from piksi_tools.console.gui_utils import MultilineTextEditor
+from piksi_tools.console.utils import (EMPTY_STR, call_repeatedly,
+                                       get_mode, mode_dict, resource_filename,
+                                       icon, swift_path)
+import webbrowser
+import threading
+import time
+
+SKYLARK_URL = 'https://swiftnav.com/skylark'
+class SkylarkView(HasTraits):
+    information = String(
+        "Skylark is Swift Navigation's high accuracy GNSS corrections service, "
+        "delivered over the internet. It removes the need for a base station, "
+        "CORS station, or VRS station.")
+    link = Button(SKYLARK_URL)
+    uuid = String()
+
+    view = View(VGroup(spring,
+                HGroup(spring, VGroup(
+                    Item(
+                        'information',
+                        height=5,
+                        width=20,
+                        show_label=False,
+                        style='readonly',
+                        editor=MultilineTextEditor(TextEditor(multi_line=True))),
+                    HGroup(spring, Item('link', show_label=False), spring),
+                    Item('uuid', label='Device UUID', width=400),
+                ), spring), spring))
+
+    def __init__(self):
+        self.real_uuid = ''
+
+    def _link_fired(self):
+        webbrowser.open(SKYLARK_URL)
+
+    def _uuid_changed(self):
+        if self.uuid != self.real_uuid:
+            threading.Thread(target=self._fix_uuid).start()
+
+    def set_uuid(self, uuid):
+        self.real_uuid = uuid
+        self.uuid = uuid
+
+    def _fix_uuid(self):
+        time.sleep(0.1)
+        self.uuid = self.real_uuid


### PR DESCRIPTION
For https://github.com/swift-nav/piksi_v3_bug_tracking/issues/1017

![screenshot from 2018-03-16 09-59-59](https://user-images.githubusercontent.com/466364/37534299-ae8616b4-2901-11e8-9701-f6baae06c610.png)

The link is a button as that seems to be the only way to do it in Traits.
The UUID is shown in an editable text box so it can be selected, but if you try to edit it, it just changes back.