### PR TITLE
Dz skylark

### DIFF
--- a/piksi_tools/console/console.py
+++ b/piksi_tools/console/console.py
@@ -251,7 +251,7 @@ class SwiftConsole(HasTraits):
                         show_label=False),
                     label='Observations', ),
                 Item('settings_view', style='custom', label='Settings'),
-                Item('update_view', style='custom', label='Firmware Update'),
+                Item('update_view', style='custom', label='Update'),
                 Tabbed(
                     Item(
                         'system_monitor_view',
@@ -365,12 +365,12 @@ class SwiftConsole(HasTraits):
                         '',
                         label='Device UUID:',
                         emphasized=True,
-                        tooltip='Corrections latency (-1 means no corrections)'
+                        tooltip='Universally Unique Device Identifier (UUID)'
                     ), Item(
                         'uuid',
                         padding=2,
                         show_label=False,
-                        style='readonly'),
+                        style='readonly', width=6),
                     Spring(springy=True),
                     Item(
                         'cnx_icon',

--- a/piksi_tools/console/settings_view.py
+++ b/piksi_tools/console/settings_view.py
@@ -101,7 +101,7 @@ class Setting(SettingBase):
             Item('value', editor=TextEditor(auto_set=False, enter_set=True),
                  visible_when='confirmed_set and not readonly'),
             Item('value', style='readonly',
-                 visible_when='not confirmed_set or readonly'),
+                 visible_when='not confirmed_set or readonly', editor=TextEditor(readonly_allow_selection=True)),
             Item('units', style='readonly'),
             UItem('default_value',
                   style='readonly',

--- a/piksi_tools/console/skylark_view.py
+++ b/piksi_tools/console/skylark_view.py
@@ -15,8 +15,6 @@ from traitsui.api import (HGroup, Item, TextEditor, VGroup, View, spring)
 from piksi_tools.console.gui_utils import MultilineTextEditor
 
 import webbrowser
-import threading
-import time
 
 SKYLARK_URL = 'https://swiftnav.com/skylark'
 
@@ -42,9 +40,8 @@ class SkylarkView(HasTraits):
                     Item('uuid', label='Device UUID', width=400, editor=TextEditor(readonly_allow_selection=True), style='readonly'),
                 ), spring), spring))
 
-    def __init__(self):
-        self.real_uuid = ''
+    def set_uuid(self, uuid):
+        self.uuid = uuid
 
     def _link_fired(self):
         webbrowser.open(SKYLARK_URL)
-

--- a/piksi_tools/console/skylark_view.py
+++ b/piksi_tools/console/skylark_view.py
@@ -39,7 +39,7 @@ class SkylarkView(HasTraits):
                         style='readonly',
                         editor=MultilineTextEditor(TextEditor(multi_line=True))),
                     HGroup(spring, Item('link', show_label=False), spring),
-                    Item('uuid', label='Device UUID', width=400),
+                    Item('uuid', label='Device UUID', width=400, editor=TextEditor(readonly_allow_selection=True), style='readonly'),
                 ), spring), spring))
 
     def __init__(self):
@@ -48,14 +48,3 @@ class SkylarkView(HasTraits):
     def _link_fired(self):
         webbrowser.open(SKYLARK_URL)
 
-    def _uuid_changed(self):
-        if self.uuid != self.real_uuid:
-            threading.Thread(target=self._fix_uuid).start()
-
-    def set_uuid(self, uuid):
-        self.real_uuid = uuid
-        self.uuid = uuid
-
-    def _fix_uuid(self):
-        time.sleep(0.1)
-        self.uuid = self.real_uuid

--- a/piksi_tools/console/update_view.py
+++ b/piksi_tools/console/update_view.py
@@ -160,7 +160,6 @@ class UpdateView(HasTraits):
 
     updating = Bool(False)
     update_stm_en = Bool(False)
-    upgrade_steps = String("Firmware upgrade status:")
 
     download_firmware = Button(label='Download Latest Firmware')
     download_directory = String()
@@ -232,18 +231,16 @@ class UpdateView(HasTraits):
                     ),
                     label="Firmware Download",
                     show_border=True),
-                Spring()
+                VGroup(
+                    Item(
+                        'stream',
+                        style='custom',
+                        editor=InstanceEditor(),
+                        show_label=False, ),
+                    show_border=True,
+                    label="Firmware Upgrade Status"),
             ),
-            UItem(
-                'upgrade_steps',
-                visible_when='not sbp_upgrade',
-                style='readonly'),
-            Item(
-                'stream',
-                style='custom',
-                editor=InstanceEditor(),
-                show_label=False, ),
-            show_border=True, ),
+            show_border=True),
     )
 
     def __init__(self,


### PR DESCRIPTION
Add on to Gareth's skylark Tab:
- Use selectable readonly field that cannot be edited for UUID on skylark and settings tab
- limit width of UUID so the window can be resized horizontally better
- rename "firmware update" to "Update"
- limit height of firmware update view so window can be displayed in size as is v1.3 console release

Here is look of UUID when truncated:
![image](https://user-images.githubusercontent.com/11276774/37623929-a1e8a712-2b83-11e8-837e-60f32f310819.png)

Here is new look of firmware update view

![image](https://user-images.githubusercontent.com/11276774/37623952-b363756c-2b83-11e8-9788-98f2e1af7e66.png)

Here is new look of skylark tab without ability to edit UUID but still ability to select
![image](https://user-images.githubusercontent.com/11276774/37623958-bd6d8e80-2b83-11e8-9978-fba164706f86.png)
![image](https://user-images.githubusercontent.com/11276774/37623974-c9031076-2b83-11e8-959f-5f354febb6b1.png)




