### PR TITLE
Add support for msg_measurement_t

### DIFF
--- a/piksi_tools/console/tracking_view.py
+++ b/piksi_tools/console/tracking_view.py
@@ -148,18 +148,15 @@ class TrackingView(CodeFiltered):
                 new_arr[-1] = 0
                 self.CN0_dict[key] = new_arr
 
-        # If the whole array is 0 we remove it
-        # for each satellite, we have a (code, prn, channel) keyed dict
-        # for each SID, an array of size MAX PLOT with the history of CN0's stored
-        # If there is no CN0 or not tracking for an epoch, 0 will be used
-        # each array can be plotted against host_time, t
         for i, s in enumerate(sbp_msg.states):
             if code_is_glo(s.mesid.code):
-                sat = self.glo_fcn_dict.get(i, 0)
+                # for Glonass satellites, store in two dictionaries FCN and SLOT
+                # so that they can both be retrieved when displaying the channel
                 if (s.mesid.sat > 90):
                     self.glo_fcn_dict[i] = s.mesid.sat - 100
                 else:
                     self.glo_slot_dict[i] = s.mesid.sat
+                sat = self.glo_fcn_dict.get(i, 0)
             else:
                 sat = s.mesid.sat
             key = (s.mesid.code, sat, i)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,5 @@ pyparsing==2.2.0
 pygments==2.2.0
 requests==2.18.4
 six==1.10.0
-sbp==2.3.14
+sbp==2.3.16
 ruamel.yaml==0.15.31


### PR DESCRIPTION
What it says, needs libsbp 2.3.16

With the new message, either FCN or SLOT for Glonass satellites can be distributed by FW.
The convention is SLOT if `sid` is [1-28] and FCN if `sid` is in the [100+FCN] range.

This PR changes the console tracking view so that both SLOT and FCN are stored in a dictionary which is indexed by the channel number rather than the FCN as it was before.

This should maintain the user experience and allow both messages to be supported by the console.