### PR TITLE
Prevent setuptools and tox from failing on builds with a -branch in tag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,13 +53,29 @@ with open(cwd + '/README.rst') as f:
 with open(cwd + '/requirements.txt') as f:
     INSTALL_REQUIRES = [i.strip() for i in f.readlines()]
 
+
+use_scm_version = {
+         'write_to': 'piksi_tools/_version.py',
+    }
+
+try:
+    # hack `meta` to strip '-branch' substring off tags for swift convention that setuptools_scm cannot handle
+    import setuptools_scm.version
+    meta = setuptools_scm.version.meta
+    setuptools_scm.version.meta = lambda tag, *args, **kwargs: \
+        meta(tag.replace('-branch', ''), *args, **kwargs)
+except ImportError:
+    # At the beginning of a tox build in a clean virtualenv, `setuptools_scm`
+    # is not yet installed when it runs `pip install setuptools_scm .[TEST] ...`
+    # so the above import fails. But the version doesn't matter, because it's
+    # just querying for dependencies.
+    use_scm_version = False
+
 setup(
     name='piksi_tools',
     description='Python tools for the Piksi GNSS receiver.',
     long_description=readme,
-    use_scm_version={
-        'write_to': 'piksi_tools/_version.py',
-    },
+    use_scm_version=use_scm_version,
     setup_requires=['setuptools_scm'],
     author='Swift Navigation',
     author_email='dev@swiftnav.com',


### PR DESCRIPTION
This should prevent errors like this due to our tagging policy of late:

`__init__.py", line 31, in version_from_scm
      File "/Users/dzollo/source/piksi_tools/setuptools_scm-2.1.0-py2.7.egg/setuptools_scm/__init__.py", line 36, in _version_from_entrypoint
      File "/Users/dzollo/source/piksi_tools/setuptools_scm-2.1.0-py2.7.egg/setuptools_scm/git.py", line 128, in parse
      File "/Users/dzollo/source/piksi_tools/setuptools_scm-2.1.0-py2.7.egg/setuptools_scm/version.py", line 135, in meta
    AssertionError: cant parse version None
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /Users/dzollo/source/piksi_tools/`

Per this issue: https://github.com/pypa/setuptools_scm/issues/87