### PR TITLE
Let bootload_v3 script inherit all of serial_link cmd line args

### DIFF
--- a/piksi_tools/bootload_v3.py
+++ b/piksi_tools/bootload_v3.py
@@ -39,9 +39,8 @@ def get_args():
     """
     Get and parse arguments.
     """
-    import argparse
     parser = serial_link.base_cl_options()
-    parser.description='Piksi Bootloader'
+    parser.description = 'Piksi Bootloader'
     parser.add_argument("file", help="the image set file to write to flash.")
     return parser.parse_args()
 

--- a/piksi_tools/bootload_v3.py
+++ b/piksi_tools/bootload_v3.py
@@ -40,25 +40,9 @@ def get_args():
     Get and parse arguments.
     """
     import argparse
-    parser = argparse.ArgumentParser(description='Piksi Bootloader')
+    parser = serial_link.base_cl_options()
+    parser.description='Piksi Bootloader'
     parser.add_argument("file", help="the image set file to write to flash.")
-    parser.add_argument(
-        '-p',
-        '--port',
-        default=[serial_link.SERIAL_PORT],
-        nargs=1,
-        help='specify the serial port to use.')
-    parser.add_argument(
-        "-b",
-        "--baud",
-        default=[serial_link.SERIAL_BAUD],
-        nargs=1,
-        help="specify the baud rate to use.")
-    parser.add_argument(
-        "-f",
-        "--ftdi",
-        help="use pylibftdi instead of pyserial.",
-        action="store_true")
     return parser.parse_args()
 
 
@@ -92,34 +76,31 @@ def main():
     Get configuration, get driver, and build handler and start it.
     """
     args = get_args()
-    port = args.port[0]
-    baud = args.baud[0]
-    use_ftdi = args.ftdi
+    driver = serial_link.get_base_args_driver(args)
     # Driver with context
-    with serial_link.get_driver(use_ftdi, port, baud) as driver:
-        # Handler with context
-        with Handler(Framer(driver.read, driver.write)) as link:
-            link.add_callback(serial_link.log_printer, SBP_MSG_LOG)
-            link.add_callback(serial_link.printer, SBP_MSG_PRINT_DEP)
+    # Handler with context
+    with Handler(Framer(driver.read, driver.write)) as link:
+        link.add_callback(serial_link.log_printer, SBP_MSG_LOG)
+        link.add_callback(serial_link.printer, SBP_MSG_PRINT_DEP)
 
-            data = open(args.file, 'rb').read()
+        data = open(args.file, 'rb').read()
 
-            def progress_cb(size):
-                sys.stdout.write("\rProgress: %d%%    \r" %
-                                 (100 * size / len(data)))
-                sys.stdout.flush()
+        def progress_cb(size):
+            sys.stdout.write("\rProgress: %d%%    \r" %
+                             (100 * size / len(data)))
+            sys.stdout.flush()
 
-            print('Transferring image file...')
-            FileIO(link).write(
-                "upgrade.image_set.bin", data, progress_cb=progress_cb)
-            print('Committing file to flash...')
-            code = shell_command(link, "upgrade_tool upgrade.image_set.bin",
-                                 300)
-            if code != 0:
-                print('Failed to perform upgrade (code = %d)' % code)
-                return
-            print('Resetting Piksi...')
-            link(MsgReset(flags=0))
+        print('Transferring image file...')
+        FileIO(link).write(
+            "upgrade.image_set.bin", data, progress_cb=progress_cb)
+        print('Committing file to flash...')
+        code = shell_command(link, "upgrade_tool upgrade.image_set.bin",
+                             300)
+        if code != 0:
+            print('Failed to perform upgrade (code = %d)' % code)
+            return
+        print('Resetting Piksi...')
+        link(MsgReset(flags=0))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Piksi Bootloader

positional arguments:
  file                  the image set file to write to flash.

optional arguments:
  -h, --help            show this help message and exit
  -p PORT, --port PORT  specify the serial port to use.
  -b BAUD, --baud BAUD  specify the baud rate to use.
  --rtscts              Enable Hardware Flow Control (RTS/CTS).
  -v, --verbose         print extra debugging information.
  -f, --ftdi            use pylibftdi instead of pyserial.
  -l, --log             serialize SBP messages to autogenerated log file.
  -r, --reset           reset device after connection.
  -o LOG_DIRNAME, --log-dirname LOG_DIRNAME
                        directory in which to create logfile.
  --logfilename LOGFILENAME
                        filename to use for log. Default filename with date
                        and timestamp is used otherwise.
  -a APPEND_LOG_FILENAME, --append-log-filename APPEND_LOG_FILENAME
                        file to append log output to.
  --file                Read with a filedriver rather than pyserial.
  -d TAGS, --tags TAGS  tags to decorate logs with.
  -t, --tcp             Use a TCP connection instead of a local serial port.
                        If TCP is selected, the port is interpreted as
                        host:port
  --expand-json         Expand fields in JSON logs


Only issue is that the logging features will have no effect in bootload_v3.  I suppose we could remove those args.