### PR TITLE
Advance hardware info settings in system info group and add product id [DEVC-472]

### DIFF
--- a/piksi_tools/console/settings.yaml
+++ b/piksi_tools/console/settings.yaml
@@ -556,7 +556,7 @@
 
 - group: system_info
   name: hw_revision
-  expert: False
+  expert: True
   type: string
   units: N/A
   default value: N/A
@@ -578,7 +578,7 @@
 
 - group: system_info
   name: hw_variant
-  expert: False
+  expert: True
   type: string
   units: N/A
   default value: N/A
@@ -586,6 +586,17 @@
   enumerated possible values:
   Description: Hardware Product Variant
   Notes: This is a read only setting that corresponds to the variant of the current hardware revision that is connected to the console.
+
+- group: system_info
+  name: product_id
+  expert: False
+  type: string
+  units: N/A
+  default value: N/A
+  readonly: True
+  enumerated possible values:
+  Description: Product ID
+  Notes: This is a read only setting that displays the product id of the device.
 
 - group: system_info
   name: imageset_build_id


### PR DESCRIPTION
Per:
https://swift-nav.atlassian.net/browse/DEVC-472
https://github.com/swift-nav/piksi_buildroot/pull/552#issuecomment-379345790

We want `product_id` to be the customer facing setting for product identification