### PR TITLE
remove RAW_IMU msg (2304) from UART1:enabled_sbp_messages default val

### DIFF
--- a/piksi_tools/console/settings.yaml
+++ b/piksi_tools/console/settings.yaml
@@ -987,7 +987,7 @@
   expert: false
   type: string
   units: N/A
-  default value: '23,29,65,72,74,81,117,134,136,144,163,165, 166,167,171,175,181,185,187,188,189,190, 257,258,259,520,522,524,526,527,528,1025, 2304,2305,2306,30583,65280,65282,65535' 
+  default value: '23,29,65,72,74,81,117,134,136,144,163,165, 166,167,171,175,181,185,187,188,189,190, 257,258,259,520,522,524,526,527,528,1025, 2305,2306,30583,65280,65282,65535' 
   readonly: false
   Description: Configure which messages should be sent on the port.
   Notes: The enabled sbp messages settings is a list of message types


### PR DESCRIPTION
to document https://github.com/swift-nav/piksi_buildroot/pull/829
Justification is in https://github.com/swift-nav/piksi_buildroot/pull/828