### PR TITLE
Fix upgrade fail for -dirty builds [DEVC-1178]

### DIFF
--- a/piksi_tools/console/update_view.py
+++ b/piksi_tools/console/update_view.py
@@ -54,7 +54,7 @@ def parse_version(version):
     if version[0] == 'v':
         version = version[1:]
     return pkparse_version(version.replace(
-        "dirty",
+        "-dirty",
         "", ))
 
 


### PR DESCRIPTION
parse_version strips "-dirty" instead of just "dirty". The dash caused
the version to be interpreted as "LegacyVersion", messing up version
comparison logic.