### PR TITLE
tell flake8 to ignore select warnings

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,11 @@ deps = flake8
        -rrequirements.txt
 commands = flake8 piksi_tools
 
+[flake8]
+# W504: ignore one of either 503 or 504
+# W605: Deprecation warning - will be relevant in python 3.7+
+extend-ignore = W504,W605
+
 [testenv:pyinstaller-linux]
 basepython = python2.7
 


### PR DESCRIPTION
W504: mutually exclusive with W503 (line break before/after binary
operators)
W605: deprecation warning for "invalid escape sequence". Will be an
error starting from python 3.7+