### PR TITLE
Create tcp driver util and wrap error handling [ESD-632]

### DIFF
--- a/piksi_tools/console/console.py
+++ b/piksi_tools/console/console.py
@@ -24,7 +24,6 @@ import warnings
 import sbp.client as sbpc
 from enable.savage.trait_defs.ui.svg_button import SVGButton
 from pyface.image_resource import ImageResource
-from sbp.client.drivers.network_drivers import TCPDriver
 from sbp.ext_events import SBP_MSG_EXT_EVENT, MsgExtEvent
 from sbp.logging import SBP_MSG_LOG, SBP_MSG_PRINT_DEP
 from sbp.navigation import SBP_MSG_POS_LLH
@@ -39,6 +38,7 @@ from traitsui.api import (EnumEditor, Handler, HGroup, HTMLEditor, ImageEditor,
                           Tabbed, UItem, VGroup, View, VSplit)
 
 import piksi_tools.serial_link as s
+from piksi_tools.utils import get_tcp_driver
 from piksi_tools import __version__ as CONSOLE_VERSION
 from piksi_tools.console.baseline_view import BaselineView
 from piksi_tools.console.callback_prompt import CallbackPrompt, ok_button
@@ -936,8 +936,7 @@ def main():
     if port and args.tcp:
         # Use the TPC driver and interpret port arg as host:port
         try:
-            host, ip_port = port.split(':')
-            selected_driver = TCPDriver(host, int(ip_port))
+            selected_driver = get_tcp_driver(port)
             connection_description = port
             cnx_info['mode'] = 'TCP/IP'
         except:  # noqa
@@ -972,7 +971,7 @@ def main():
                 print("Using TCP/IP at address %s and port %d" % (ip_address,
                                                                   ip_port))
                 cnx_info['mode'] = cnx_type_list[1]
-                selected_driver = TCPDriver(ip_address, int(ip_port))
+                selected_driver = get_tcp_driver(ip_address, ip_port)
                 connection_description = ip_address + ":" + str(ip_port)
             else:
                 cnx_info['mode'] = cnx_type_list[0]

--- a/piksi_tools/fileio.py
+++ b/piksi_tools/fileio.py
@@ -19,7 +19,7 @@ import threading
 import sys
 
 from sbp.client import Framer, Handler
-from sbp.client.drivers.network_drivers import TCPDriver
+from piksi_tools.utils import get_tcp_driver
 from sbp.file_io import (SBP_MSG_FILEIO_READ_DIR_RESP,
                          SBP_MSG_FILEIO_READ_RESP, SBP_MSG_FILEIO_WRITE_RESP,
                          MsgFileioReadDirReq, MsgFileioReadDirResp,
@@ -459,11 +459,7 @@ def main():
     port = args.port[0]
     baud = args.baud[0]
     if args.tcp:
-        try:
-            host, port = port.split(':')
-            selected_driver = TCPDriver(host, int(port))
-        except:  # noqa
-            raise Exception('Invalid host and/or port')
+        selected_driver = get_tcp_driver(port)
     else:
         selected_driver = serial_link.get_driver(args.ftdi, port, baud)
 

--- a/piksi_tools/fileio.py
+++ b/piksi_tools/fileio.py
@@ -19,13 +19,13 @@ import threading
 import sys
 
 from sbp.client import Framer, Handler
-from piksi_tools.utils import get_tcp_driver
 from sbp.file_io import (SBP_MSG_FILEIO_READ_DIR_RESP,
                          SBP_MSG_FILEIO_READ_RESP, SBP_MSG_FILEIO_WRITE_RESP,
                          MsgFileioReadDirReq, MsgFileioReadDirResp,
                          MsgFileioReadReq, MsgFileioRemove, MsgFileioWriteReq)
 
 from piksi_tools import serial_link
+from piksi_tools.utils import get_tcp_driver
 
 MAX_PAYLOAD_SIZE = 255
 SBP_FILEIO_WINDOW_SIZE = 100

--- a/piksi_tools/serial_link.py
+++ b/piksi_tools/serial_link.py
@@ -22,7 +22,7 @@ import uuid
 import serial.tools.list_ports
 from sbp.client import Forwarder, Framer, Handler
 from sbp.client.drivers.cdc_driver import CdcDriver
-from sbp.client.drivers.network_drivers import HTTPDriver, TCPDriver
+from sbp.client.drivers.network_drivers import HTTPDriver
 from sbp.client.drivers.pyftdi_driver import PyFTDIDriver
 from sbp.client.drivers.pyserial_driver import PySerialDriver
 from sbp.client.drivers.file_driver import FileDriver
@@ -31,7 +31,7 @@ from sbp.client.loggers.null_logger import NullLogger
 from sbp.logging import SBP_MSG_LOG, SBP_MSG_PRINT_DEP, MsgLog
 from sbp.piksi import MsgReset
 
-from piksi_tools.utils import mkdir_p
+from piksi_tools.utils import (mkdir_p, get_tcp_driver)
 
 SERIAL_PORT = "/dev/ttyUSB0"
 SERIAL_BAUD = 115200
@@ -351,12 +351,7 @@ def run(args, link):
 def get_base_args_driver(args):
     driver = None
     if args.tcp:
-        try:
-            host, port = args.port.split(':')
-            driver = TCPDriver(host, int(port))
-        except:  # noqa
-            import traceback
-            raise Exception('Invalid host and/or port: {0}'.format(traceback.format_exc()))
+        driver = get_tcp_driver(args.port)
     else:
         driver = get_driver(
             args.ftdi, args.port, args.baud, args.file, rtscts=args.rtscts)

--- a/piksi_tools/serial_link.py
+++ b/piksi_tools/serial_link.py
@@ -31,7 +31,7 @@ from sbp.client.loggers.null_logger import NullLogger
 from sbp.logging import SBP_MSG_LOG, SBP_MSG_PRINT_DEP, MsgLog
 from sbp.piksi import MsgReset
 
-from piksi_tools.utils import (mkdir_p, get_tcp_driver)
+from piksi_tools.utils import mkdir_p, get_tcp_driver
 
 SERIAL_PORT = "/dev/ttyUSB0"
 SERIAL_BAUD = 115200

--- a/piksi_tools/utils.py
+++ b/piksi_tools/utils.py
@@ -14,6 +14,9 @@ from __future__ import print_function
 import errno
 import os
 
+from sbp.client.drivers.network_drivers import TCPDriver
+import socket
+
 
 def wrap_sbp_dict(data_dict, timestamp):
     return {'data': data_dict, 'time': timestamp}
@@ -38,3 +41,21 @@ def sopen(path, mode):
     '''
     mkdir_p(os.path.dirname(path))
     return open(path, mode)
+
+
+def get_tcp_driver(host, port=None):
+    ''' Factory method helper for opening TCPDriver from host and port
+    '''
+    try:
+        if port is None:
+            host, port = host.split(':')
+        return TCPDriver(host,
+                         int(port),
+                         raise_initial_timeout=True)
+    except ValueError:
+        raise Exception('Invalid format (use ip_address:port): {}'.format(host))
+    except socket.timeout:
+        raise Exception('TCP connection timed out. Check host: {}'.format(host))
+    except Exception as e:
+        import traceback
+        raise Exception('Invalid host and/or port: {0}'.format(traceback.format_exc()))


### PR DESCRIPTION
Requires https://github.com/swift-nav/libsbp/pull/617 in order to work.

This change will wrap all attempts at TCP connection using the `libsbp` driver with standard error codes and a parsing scheme that seems to be common amongst tools.

Introduces the behavior that a timeout will cause the initialization to fail rather than hang.