### PR TITLE
Allow tracking view to age out old data [ESD-902]

### DIFF
--- a/piksi_tools/console/tracking_view.py
+++ b/piksi_tools/console/tracking_view.py
@@ -10,7 +10,6 @@
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 
-import sys
 import time
 from collections import defaultdict, deque
 import threading
@@ -226,17 +225,13 @@ class TrackingView(CodeFiltered):
             for each in list(self.plot.plots.keys()):
                 if each not in [str(a) for a in self.CN0_dict.keys()] and each != 't':
                     try:
-                        sys.stderr.write("Deleting plot: {}\n".format(each))
                         self.plot.delplot(each)
                     except KeyError:
-                        sys.stderr.write("Key error while deleting plot: {}\n".format(each))
-                        # pass
+                        pass
                     try:
-                        sys.stderr.write("Deleting plot data: {}\n".format(each))
                         self.plot_data.del_data(each)
                     except KeyError:
-                        sys.stderr.write("Key error while deleting plot data: {}\n".format(each))
-                        # pass
+                        pass
             # add/remove plot as neccesary and build legend
             for k, cno_array in self.CN0_dict.items():
                 key = str(k)
@@ -255,9 +250,6 @@ class TrackingView(CodeFiltered):
                         self.plot.delplot(key)
             plots = dict(list(zip(plot_labels, plots)))
             self.plot.legend.plots = plots
-            sys.stderr.write("{} {}\n".format(len(self.plot_data.list_data()), len(self.plot.plots)))
-            sys.stderr.write("{}\n".format(sum(len(self.plot_data.get_data(K)) for K in self.plot_data.list_data())))
-            sys.stderr.flush()
 
     def _legend_visible_changed(self):
         if self.plot:

--- a/piksi_tools/fileio.py
+++ b/piksi_tools/fileio.py
@@ -239,7 +239,7 @@ class FileIO(object):
         """
         offset = 0
         chunksize = MAX_PAYLOAD_SIZE - 4
-        closure = {'mostly_done': False, 'done': False, 'buf': {}, 'pending':set()}
+        closure = {'mostly_done': False, 'done': False, 'buf': {}, 'pending': set()}
 
         def cb(req, resp):
             closure['pending'].remove(req.offset)


### PR DESCRIPTION
Tracking view adds data to it's `CN0_dict` memory but never ages out old data, thus anything that shows up will forever be held in the dictionary, this meant that logic to delete plots and plot data was never triggered.  Add a mechanism to figure out if data in the dictionary is older than the oldest currently active plot point and remove it if it is.