### PR TITLE
remove channel from plotting key [ESD-614]

### DIFF
--- a/piksi_tools/console/tracking_view.py
+++ b/piksi_tools/console/tracking_view.py
@@ -77,7 +77,7 @@ color_dict = {
 
 
 def get_color(key):
-    code, sat, ch = key
+    code, sat = key
 
     # reuse palatte for glo signals
     if code_is_glo(code):
@@ -94,13 +94,13 @@ def get_color(key):
 
 
 def get_label(key, extra):
-    code, sat, ch = key
-    lbl = 'Ch {ch:02d}: {code} '.format(ch=ch, code=code_to_str(code))
+    code, sat = key
+    lbl = '{code} '.format(code=code_to_str(code))
 
     if code_is_glo(code):
         lbl += 'F{sat:0=+3d}'.format(sat=sat)
-        if ch in extra:
-            lbl += ' R{slot:02d}'.format(slot=extra[ch])
+        if sat in extra:
+            lbl += ' R{slot:02d}'.format(slot=extra[sat])
     elif code_is_sbas(code):
         lbl += 'S{sat:3d}'.format(sat=sat)
     elif code_is_bds(code):
@@ -152,12 +152,12 @@ class TrackingView(CodeFiltered):
                     # so that they can both be retrieved when displaying the channel
                     if (s.mesid.sat > 90):
                         self.glo_fcn_dict[i] = s.mesid.sat - 100
-                    else:
-                        self.glo_slot_dict[i] = s.mesid.sat
                     sat = self.glo_fcn_dict.get(i, 0)
+                    if (s.mesid.sat <= 90):
+                        self.glo_slot_dict[sat] = s.mesid.sat
                 else:
                     sat = s.mesid.sat
-                key = (s.mesid.code, sat, i)
+                key = (s.mesid.code, sat)
                 codes_that_came.append(key)
                 if s.cn0 != 0:
                     self.CN0_dict[key].append(s.cn0 / 4.0)
@@ -186,11 +186,14 @@ class TrackingView(CodeFiltered):
             # each array can be plotted against host_time, t
             for i, s in enumerate(sbp_msg.states):
                 if code_is_glo(s.sid.code):
-                    sat = s.fcn - GLO_FCN_OFFSET
-                    self.glo_slot_dict[i] = s.sid.sat
+                    if (s.sid.sat > 90):
+                        sat = s.sid.sat - 100
+                    else:
+                        sat = s.fcn - GLO_FCN_OFFSET
+                    self.glo_slot_dict[sat] = s.sid.sat
                 else:
                     sat = s.sid.sat
-                key = (s.sid.code, sat, i)
+                key = (s.sid.code, sat)
                 codes_that_came.append(key)
                 if s.cn0 != 0:
                     self.CN0_dict[key].append(s.cn0 / 4.0)


### PR DESCRIPTION
Channel is entirely local, based only on the order in which we receive
satellite measurements. If the piksi changes this order (for example, if
it lost and then reacquired signals), then the channel will likely
change, rendering it useless as an identifying metric.