### PR TITLE
Add metrics table to system monitor view

### DIFF
--- a/piksi_tools/console/settings.yaml
+++ b/piksi_tools/console/settings.yaml
@@ -2258,7 +2258,7 @@
   name: ota_enabled
   type: boolean
   expert: true
-  default value: false
+  default value: 'false'
   readonly: false
   units: N/A
   Description: Enables or disables the Over-The-Air upgrade daemon.
@@ -2270,11 +2270,11 @@
   name: ota_debug
   type: boolean
   expert: true
-  default value: false
+  default value: 'false'
   readonly: false
   units: N/A
   Description: Enables or disables the Over-The-Air upgrade daemon's verbose output.
-  Notes: ota enabled must be False in order to change this setting.
+  Notes: the "ota enabled" setting must be "False" in order to change this setting.
 
 - group: system
   name: ota_url

--- a/piksi_tools/console/settings.yaml
+++ b/piksi_tools/console/settings.yaml
@@ -1595,7 +1595,7 @@
   expert: false
   type: integer
   units: us (microseconds)
-  default value: '200000'
+  default value: '2000'
   readonly: false
   enumerated possible values:
   Description: Number of microseconds the PPS will remain active (allowed range from 1 to 999999 us).
@@ -1616,12 +1616,12 @@
   name: offset
   expert: false
   type: integer
-  units: us (microseconds)
+  units: ns (nanoseconds)
   default value: '0'
   readonly: false
   enumerated possible values:
-  Description: Offset in microseconds between GPS time and the PPS.
-  Notes:
+  Description: Offset in nanoseconds between GPS time and the PPS.
+  Notes: This setting can be used to compensate for cable delays in timing systems.
 
 - group: pps
   name: frequency
@@ -2258,7 +2258,7 @@
   name: ota_enabled
   type: boolean
   expert: true
-  default value: 'false'
+  default value: 'False'
   readonly: false
   units: N/A
   Description: Enables or disables the Over-The-Air upgrade daemon.
@@ -2270,11 +2270,11 @@
   name: ota_debug
   type: boolean
   expert: true
-  default value: 'false'
+  default value: 'False'
   readonly: false
   units: N/A
   Description: Enables or disables the Over-The-Air upgrade daemon's verbose output.
-  Notes: the "ota enabled" setting must be "False" in order to change this setting.
+  Notes: The "ota enabled" setting must be "False" in order to change this setting.
 
 - group: system
   name: ota_url
@@ -2575,3 +2575,29 @@
     3456/10 would provide message with ID 3456 at 1/10th the normal rate. For Ethernet,
     the default value is optimal for logging and communication with the console.
 
+- group: pps
+  name: propagation_mode
+  expert: false
+  type: enum
+  units: N/A
+  default value: Time Limited
+  enumerated possible values: None,Time Limited,Unlimited
+  Description: Configures the behavior of the PPS when no GNSS fix is available.
+
+- group: pps
+  name: propagation_timeout
+  expert: false
+  type: float 
+  units: seconds
+  default value: '5'
+  readonly: false
+  Description: Configures the timeout length of the PPS when using the "Time Limited" propagation mode.
+
+- group: csac
+  name: telemetry_enabled
+  expert: false
+  type: boolean
+  units: N/A
+  default value: 'false'
+  readonly: false
+  Description: Enables or disables the CSAC daemon which can communicate with Microsemi timing devices on UART0

--- a/piksi_tools/console/system_monitor_view.py
+++ b/piksi_tools/console/system_monitor_view.py
@@ -11,17 +11,16 @@
 
 from __future__ import absolute_import
 
-from sbp.piksi import (SBP_MSG_NETWORK_STATE_RESP, SBP_MSG_THREAD_STATE,
+from sbp.piksi import (SBP_MSG_THREAD_STATE,
                        SBP_MSG_UART_STATE, SBP_MSG_UART_STATE_DEPA,
-                       SBP_MSG_DEVICE_MONITOR,
-                       MsgNetworkStateReq, MsgReset)
-from sbp.system import SBP_MSG_HEARTBEAT
-from traits.api import Dict, HasTraits, Int, Float, List
+                       SBP_MSG_DEVICE_MONITOR, MsgReset)
+from sbp.system import SBP_MSG_HEARTBEAT, SBP_MSG_CSAC_TELEMETRY, SBP_MSG_CSAC_TELEMETRY_LABELS
+from traits.api import Dict, HasTraits, Int, Float, List, Bool
 from traits.etsconfig.api import ETSConfig
 from traitsui.api import HGroup, Item, TabularEditor, VGroup, View
 from traitsui.tabular_adapter import TabularAdapter
 
-from .utils import resource_filename, sizeof_fmt
+from .utils import resource_filename
 
 if ETSConfig.toolkit != 'null':
     from enable.savage.trait_defs.ui.svg_button import SVGButton
@@ -35,13 +34,17 @@ class SimpleAdapter(TabularAdapter):
     columns = [('Thread Name', 0), ('CPU %', 1), ('Stack Free', 2)]
 
 
+class SimpleCSACAdapter(TabularAdapter):
+    columns = [('Metric Name', 0), ('Value', 1)]
+
+
 class SystemMonitorView(HasTraits):
     python_console_cmds = Dict()
 
     _threads_table_list = List()
+    _csac_telem_list = List()
+    _csac_received = Bool(False)
     threads = List()
-
-    _network_info = List()
 
     msg_obs_avg_latency_ms = Int(0)
     msg_obs_min_latency_ms = Int(0)
@@ -120,7 +123,8 @@ class SystemMonitorView(HasTraits):
                                 style='readonly',
                                 format_str='%dms'),
                             label='Period',
-                            show_border=True, ),
+                            show_border=True
+                        ),
                         show_border=True,
                         label="Observation Connection Monitor"),
                     Item('piksi_reset_button', show_label=False, width=0.50)
@@ -139,8 +143,18 @@ class SystemMonitorView(HasTraits):
                     show_border=True,
                     label="Device Monitor",
                 ),
-            ),
-        )
+                VGroup(
+                    Item(
+                        '_csac_telem_list',
+                        style='readonly',
+                        editor=TabularEditor(adapter=SimpleCSACAdapter()),
+                        show_label=False),
+                    show_border=True,
+                    label="Metrics",
+                    visible_when='_csac_received'
+                )
+            )
+        ),
     )
 
     def update_threads(self):
@@ -168,21 +182,25 @@ class SystemMonitorView(HasTraits):
         sbp_msg.cpu /= 10.
         self.threads.append((sbp_msg.name, sbp_msg))
 
+    def csac_header_callback(self, sbp_msg, **metadata):
+        self.headers = sbp_msg.telemetry_labels.split(',')
+        self.telem_header_index = sbp_msg.id
+
+    def csac_telem_callback(self, sbp_msg, **metadata):
+        self._csac_telem_list = []
+        if self.telem_header_index is not None:
+            if sbp_msg.id == self.telem_header_index:
+                self._csac_received = True
+                metrics_of_interest = ['Status', 'Alarm', 'Mode', 'Phase', 'DiscOK']
+                telems = sbp_msg.telemetry.split(',')
+                for i, each in enumerate(self.headers):
+                    if each in metrics_of_interest:
+                        self._csac_telem_list.append((each, telems[i]))
+
     def _piksi_reset_button_fired(self):
         self.link(MsgReset(flags=0))
 
-    def _network_refresh_button_fired(self):
-        self._network_info = []
-        self.link(MsgNetworkStateReq())
-
-    def _network_callback(self, m, **metadata):
-        self._network_info.append(
-            (m.interface_name, ip_bytes_to_string(m.ipv4_address),
-             ((m.flags & (1 << 6)) != 0),
-             sizeof_fmt(m.tx_bytes), sizeof_fmt(m.rx_bytes)))
-
     def uart_state_callback(self, m, **metadata):
-
         self.msg_obs_avg_latency_ms = m.latency.avg
         self.msg_obs_min_latency_ms = m.latency.lmin
         self.msg_obs_max_latency_ms = m.latency.lmax
@@ -196,13 +214,16 @@ class SystemMonitorView(HasTraits):
     def __init__(self, link):
         super(SystemMonitorView, self).__init__()
         self.link = link
+        self.telem_header_index = None
         self.link.add_callback(self.heartbeat_callback, SBP_MSG_HEARTBEAT)
         self.link.add_callback(self.device_callback, SBP_MSG_DEVICE_MONITOR)
         self.link.add_callback(self.thread_state_callback,
                                SBP_MSG_THREAD_STATE)
         self.link.add_callback(self.uart_state_callback,
                                [SBP_MSG_UART_STATE, SBP_MSG_UART_STATE_DEPA])
-        self.link.add_callback(self._network_callback,
-                               SBP_MSG_NETWORK_STATE_RESP)
+        self.link.add_callback(self.csac_telem_callback,
+                               SBP_MSG_CSAC_TELEMETRY)
+        self.link.add_callback(self.csac_header_callback,
+                               SBP_MSG_CSAC_TELEMETRY_LABELS)
 
         self.python_console_cmds = {'mon': self}


### PR DESCRIPTION
This is a GUI widget for metrics that we can use to display any relevant metrics that need to be shown to user.  In this implementation, we show MSG_CSAC_TELEM.  The widget will only appear if these SBP messages are received.