### PR TITLE
added checks for reading from settings dictionary in update_view

### DIFF
--- a/piksi_tools/console/update_view.py
+++ b/piksi_tools/console/update_view.py
@@ -368,7 +368,8 @@ class UpdateView(HasTraits):
         ins_settings = self.settings.get('ins', None)
         ins_output_mode = None
         if ins_settings is not None:
-            ins_output_mode = ins_settings.get('output_mode')        
+            ins_output_mode = ins_settings.get('output_mode')
+     
         if (ins_output_mode is not None) and (ins_output_mode not in ins_upgrade_modes):
             ins_disable_prompt = \
                 prompt.CallbackPrompt(

--- a/piksi_tools/console/update_view.py
+++ b/piksi_tools/console/update_view.py
@@ -365,7 +365,12 @@ class UpdateView(HasTraits):
         thread.
         """
         ins_upgrade_modes = set(['Disabled', 'disabled'])
-        if(self.settings['ins']['output_mode'].value not in ins_upgrade_modes):
+        ins_settings = self.settings.get('ins', None)
+        ins_output_mode = None
+        if ins_settings is not None:
+            ins_output_mode = ins_settings.get('output_mode')
+        
+        if (ins_output_mode is not None) and (ins_output_mode not in ins_upgrade_modes):
             ins_disable_prompt = \
                 prompt.CallbackPrompt(
                     title="Unsupported Update Request",

--- a/piksi_tools/console/update_view.py
+++ b/piksi_tools/console/update_view.py
@@ -368,8 +368,7 @@ class UpdateView(HasTraits):
         ins_settings = self.settings.get('ins', None)
         ins_output_mode = None
         if ins_settings is not None:
-            ins_output_mode = ins_settings.get('output_mode')
-        
+            ins_output_mode = ins_settings.get('output_mode')        
         if (ins_output_mode is not None) and (ins_output_mode not in ins_upgrade_modes):
             ins_disable_prompt = \
                 prompt.CallbackPrompt(

--- a/piksi_tools/console/update_view.py
+++ b/piksi_tools/console/update_view.py
@@ -369,7 +369,7 @@ class UpdateView(HasTraits):
         ins_output_mode = None
         if ins_settings is not None:
             ins_output_mode = ins_settings.get('output_mode')
-     
+
         if (ins_output_mode is not None) and (ins_output_mode not in ins_upgrade_modes):
             ins_disable_prompt = \
                 prompt.CallbackPrompt(


### PR DESCRIPTION
previous build failed to upgrade non-ins hardware due to 'ins' setting group not being populated. changed the settings read to check for the presence of the 'ins' group and 'output_mode' setting before checking the value.