### PR TITLE
Fix missing value request when reading settings for INS upgrade warning

### DIFF
--- a/piksi_tools/console/update_view.py
+++ b/piksi_tools/console/update_view.py
@@ -368,8 +368,7 @@ class UpdateView(HasTraits):
         ins_settings = self.settings.get('ins', None)
         ins_output_mode = None
         if ins_settings is not None:
-            ins_output_mode = ins_settings.get('output_mode')
-
+            ins_output_mode = ins_settings.get('output_mode').value
         if (ins_output_mode is not None) and (ins_output_mode not in ins_upgrade_modes):
             ins_disable_prompt = \
                 prompt.CallbackPrompt(


### PR DESCRIPTION
Settings read request was missing value check.