### PR TITLE
Update requests dep to resolve security warning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ pyserial==3.0.1
 pylibftdi==0.16.1.2
 pyparsing==2.2.0
 pygments==2.2.0
-requests==2.18.4
+requests==2.20.0
 six==1.10.0
 sbp==2.4.5
 ruamel.yaml==0.15.31


### PR DESCRIPTION
Bump library dependency to resolve this warning:

![screen shot 2019-01-03 at 10 30 49 pm](https://user-images.githubusercontent.com/183436/50676098-53b77d80-0fa7-11e9-9fd6-c070fa3b7bae.png)
