### PR TITLE
Add tentative python 3 support to the most important command line tools [EX-477]

### DIFF
--- a/piksi_tools/bootload_v3.py
+++ b/piksi_tools/bootload_v3.py
@@ -79,10 +79,7 @@ def main():
     # Driver with context
     # Handler with context
     with Handler(Framer(driver.read, driver.write)) as link:
-        link.add_callback(serial_link.log_printer, SBP_MSG_LOG)
-        link.add_callback(serial_link.printer, SBP_MSG_PRINT_DEP)
-
-        data = open(args.file, 'rb').read()
+        data = bytearray(open(args.file, 'rb').read())
 
         def progress_cb(size):
             sys.stdout.write("\rProgress: %d%%    \r" %
@@ -91,10 +88,12 @@ def main():
 
         print('Transferring image file...')
         FileIO(link).write(
-            "upgrade.image_set.bin", data, progress_cb=progress_cb)
+            b"upgrade.image_set.bin", data, progress_cb=progress_cb)
         print('Committing file to flash...')
-        code = shell_command(link, "upgrade_tool upgrade.image_set.bin",
-                             300)
+        link.add_callback(serial_link.log_printer, SBP_MSG_LOG)
+        link.add_callback(serial_link.printer, SBP_MSG_PRINT_DEP)
+
+        code = shell_command(link, b"upgrade_tool upgrade.image_set.bin", 300)
         if code != 0:
             print('Failed to perform upgrade (code = %d)' % code)
             return

--- a/piksi_tools/fileio.py
+++ b/piksi_tools/fileio.py
@@ -10,6 +10,7 @@
 # WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 
 from __future__ import absolute_import, print_function
+from future.builtins import bytes  # makes python 2 bytes more similar to python 3
 
 import copy
 import itertools
@@ -229,12 +230,12 @@ class FileIO(object):
 
         Parameters
         ----------
-        filename : str
+        filename : bytes
             Name of the file to read.
 
         Returns
         -------
-        out : str
+        out : bytearray
             Contents of the file.
         """
         offset = 0
@@ -265,18 +266,18 @@ class FileIO(object):
             sorted_buffers = sorted(closure['buf'].items(), key=lambda kv: kv[0])
             return bytearray(itertools.chain.from_iterable(kv[1] for kv in sorted_buffers))
 
-    def readdir(self, dirname='.'):
+    def readdir(self, dirname=b'.'):
         """
         List the files in a directory.
 
         Parameters
         ----------
-        dirname : str (optional)
+        dirname : bytes (optional)
             Name of the directory to list. Defaults to the root directory.
 
         Returns
         -------
-        out : [str]
+        out : [bytes]
             List of file names.
         """
         files = []
@@ -292,10 +293,11 @@ class FileIO(object):
             reply = MsgFileioReadDirResp(reply)
             if reply.sequence != seq:
                 raise Exception("Reply FILEIO_READ_DIR doesn't match request (%d vs %d)" % (reply.sequence, seq))
-            chunk = str(bytearray(reply.contents)).rstrip('\0')
+            chunk = bytes(reply.contents).rstrip(b'\0')
+
             if len(chunk) == 0:
                 return files
-            files += chunk.split('\0')
+            files += chunk.split(b'\0')
 
     def remove(self, filename):
         """
@@ -303,7 +305,7 @@ class FileIO(object):
 
         Parameters
         ----------
-        filename : str
+        filename : bytes
             Name of the file to delete.
         """
         msg = MsgFileioRemove(filename=filename)
@@ -315,9 +317,9 @@ class FileIO(object):
 
         Parameters
         ----------
-        filename : str
+        filename : bytes
             Name of the file to write to.
-        data : str
+        data : bytearray
             Data to write
         offset : int (optional)
             Offset into the file at which to start writing in bytes.
@@ -348,9 +350,9 @@ class FileIO(object):
                 chunk = data[offset:offset + chunksize - 1]
                 msg = MsgFileioWriteReq(
                     sequence=seq,
-                    filename=(filename + '\0' + chunk),
                     offset=offset,
-                    data='')
+                    filename=filename + b'\x00',
+                    data=chunk)
                 sr.send(msg)
                 offset += len(chunk)
                 if (progress_cb is not None and seq % PROGRESS_CB_REDUCTION_FACTOR == 0):
@@ -393,11 +395,11 @@ def print_dir_listing(files):
 
     Parameters
     ----------
-    files : [str]
+    files : [bytes]
         List of file names in the directory.
     """
     for f in files:
-        print(f)
+        print(f.decode('ascii', 'replace'))
 
 
 def get_args():
@@ -455,6 +457,13 @@ def get_args():
     return parser.parse_args()
 
 
+def raw_filename(str_filename):
+    """Return a filename in raw bytes from a command line option string."""
+    # Non-unicode characters/bytes in the command line options are decoded by
+    # using 'surrogateescape' and file system encoding, and this reverts that.
+    return bytes(str_filename, sys.getfilesystemencoding(), 'surrogateescape')
+
+
 def main():
     args = get_args()
     port = args.port[0]
@@ -471,21 +480,23 @@ def main():
             f = FileIO(link)
             try:
                 if args.write:
-                    f.write(args.write[1], open(args.write[0]).read())
+                    f.write(raw_filename(args.write[1]), bytearray(open(args.write[0], 'rb').read()))
                 elif args.read:
                     if len(args.read) not in [1, 2]:
                         sys.stderr.write("Error: fileio read requires either 1 or 2 arguments, SOURCE and optionally DEST.")
                         sys.exit(1)
-                    data = f.read(args.read[0])
+                    data = f.read(raw_filename(args.read[0]))
                     if len(args.read) == 2:
-                        with open(args.read[1], ('wb' if args.hex else 'w')) as fd:
+                        with open(args.read[1], ('w' if args.hex else 'wb')) as fd:
                             fd.write(hexdump(data) if args.hex else data)
+                    elif args.hex:
+                        print(hexdump(data))
                     else:
-                        print(hexdump(data) if args.hex else data)
+                        print(data.decode('ascii', 'replace'))
                 elif args.delete:
-                    f.remove(args.delete[0])
+                    f.remove(raw_filename(args.delete[0]))
                 elif args.list is not None:
-                    print_dir_listing(f.readdir(args.list[0]))
+                    print_dir_listing(f.readdir(raw_filename(args.list[0])))
                 else:
                     print("No command given, listing root directory:")
                     print_dir_listing(f.readdir())

--- a/piksi_tools/fileio.py
+++ b/piksi_tools/fileio.py
@@ -33,6 +33,7 @@ SBP_FILEIO_WINDOW_SIZE = 100
 SBP_FILEIO_TIMEOUT = 5.0
 MINIMUM_RETRIES = 3
 PROGRESS_CB_REDUCTION_FACTOR = 100
+TEXT_ENCODING = 'utf-8'  # used for printing out directory listings and files
 
 
 class PendingWrite(object):
@@ -399,7 +400,7 @@ def print_dir_listing(files):
         List of file names in the directory.
     """
     for f in files:
-        print(f.decode('ascii', 'replace'))
+        print(f.decode(TEXT_ENCODING, 'replace'))
 
 
 def get_args():
@@ -461,6 +462,9 @@ def raw_filename(str_filename):
     """Return a filename in raw bytes from a command line option string."""
     # Non-unicode characters/bytes in the command line options are decoded by
     # using 'surrogateescape' and file system encoding, and this reverts that.
+    # References:
+    # https://www.python.org/dev/peps/pep-0383/
+    # https://docs.python.org/3/library/os.html#file-names-command-line-arguments-and-environment-variables
     return bytes(str_filename, sys.getfilesystemencoding(), 'surrogateescape')
 
 
@@ -492,7 +496,7 @@ def main():
                     elif args.hex:
                         print(hexdump(data))
                     else:
-                        print(data.decode('ascii', 'replace'))
+                        print(data.decode(TEXT_ENCODING, 'replace'))
                 elif args.delete:
                     f.remove(raw_filename(args.delete[0]))
                 elif args.list is not None:

--- a/piksi_tools/fileio.py
+++ b/piksi_tools/fileio.py
@@ -400,7 +400,7 @@ def print_dir_listing(files):
         List of file names in the directory.
     """
     for f in files:
-        print(f.decode(TEXT_ENCODING, 'replace'))
+        print(printable_text_from_device(f))
 
 
 def get_args():
@@ -468,6 +468,15 @@ def raw_filename(str_filename):
     return bytes(str_filename, sys.getfilesystemencoding(), 'surrogateescape')
 
 
+def printable_text_from_device(data):
+    """Takes text data from the device as bytes and returns a string where any
+       characters incompatible with stdout have been replaced with '?'"""
+    str = data.decode(TEXT_ENCODING, 'replace')\
+              .encode(sys.stdout.encoding, 'replace')\
+              .decode(sys.stdout.encoding)
+    return str
+
+
 def main():
     args = get_args()
     port = args.port[0]
@@ -496,7 +505,7 @@ def main():
                     elif args.hex:
                         print(hexdump(data))
                     else:
-                        print(data.decode(TEXT_ENCODING, 'replace'))
+                        print(printable_text_from_device(data))
                 elif args.delete:
                     f.remove(raw_filename(args.delete[0]))
                 elif args.list is not None:

--- a/piksi_tools/serial_link.py
+++ b/piksi_tools/serial_link.py
@@ -218,7 +218,7 @@ def printer(sbp_msg, **metadata):
     sbp_msg: SBP
       SBP Message to print out.
     """
-    print(sbp_msg.payload, end=' ')
+    print(sbp_msg.payload.decode('ascii', 'replace'), end=' ')
 
 
 def log_printer(sbp_msg, **metadata):
@@ -241,7 +241,7 @@ def log_printer(sbp_msg, **metadata):
         7: 'DEBUG'
     }
     m = MsgLog(sbp_msg)
-    print(levels[m.level], m.text)
+    print(levels[m.level], m.text.decode('ascii', 'replace'))
 
 
 def swriter(link):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ cython==0.26
 pytest==3.2.1
 configparser
 tox==3.2.1 
+future==0.17.1
 futures==3.1.1
 pep8==1.7.0
 pyserial==3.0.1


### PR DESCRIPTION
This adds tentative python 3 support to the most important command line apps:
* fileio.py
* bootload_v3.py
* settings.py
* serial_link.py
while also maintaining their python 2 support. Other command line apps are not updated to python 3 for now and are semi-abandoned (and in fact there could be also other issues in them already as they don't seem to be well maintained).

The python 3 support is preliminary and can in principle be tested on top of the WIP libsbp python 3 branch https://github.com/swift-nav/libsbp/commits/silverjam/py3 with two notes:
* needs rebasing (I tested using a locally rebased copy but didn't commit the changes yet, to be done in EX-476)
* serial_link.py's log-to-file functionality needs a minor fix to a logger class in libsbp (likewise an uncommitted local change at the moment)

The python 2 support works on top of the normal libsbp master branch.

Minor changes to the cli tools may be necessary after or in conjunction with EX-476 (finalizing libsbp python 3 support).