### PR TITLE
Streamline settings cli tool write handling [EX-477]

### DIFF
--- a/piksi_tools/bootload_v3.py
+++ b/piksi_tools/bootload_v3.py
@@ -78,7 +78,7 @@ def main():
     driver = serial_link.get_base_args_driver(args)
     # Driver with context
     # Handler with context
-    with Handler(Framer(driver.read, driver.write)) as link:
+    with Handler(Framer(driver.read, driver.write, verbose=args.verbose)) as link:
         data = bytearray(open(args.file, 'rb').read())
 
         def progress_cb(size):

--- a/piksi_tools/settings.py
+++ b/piksi_tools/settings.py
@@ -322,7 +322,7 @@ def main():
     command = args.command
     return_code = 0
     driver = serial_link.get_base_args_driver(args)
-    with Handler(Framer(driver.read, driver.write)) as link:
+    with Handler(Framer(driver.read, driver.write, verbose=args.verbose)) as link:
         settings = Settings(link, timeout=args.timeout)
         with settings:
             if command == 'write':


### PR DESCRIPTION
This PR is an enhancement suggestion and depending on review comments, it can be merged, merged after minor or major changes or even rejected. A couple of points worth considering:
* I think (based on code and some discussion with Dennis) that the existing write implementation in settings.py is essentially a hack from a time when the write response msg didn't exist. It has been slightly modified to take into account write responses but not thoroughly. This PR makes "a more thorough" attempt.
* this PR drops retry attempts on writes. As I fixed the --timeout command line option recently, I think that's a better way to handle possibly failing writes due to network delays. Did the retries have any other value?
* there's no "NTRIP must be disabled to modify settings" warning anymore if attempting to write ntrip settings when it is enabled as that came from the log messages (a hack that resulted also in lots of unrelated junk being printed out). Instead, there's a bit more generic read-only warning that comes from the "proper" channel, i.e., write response
* the old implementation did some heuristic value checks in the confirm-by-reread method that the proposed one doesn't. I don't think those are needed on the client side: any failure checks should be done on the device firmware side and return write response with status SETTINGS_WR_VALUE_REJECTED or SETTINGS_WR_PARSE_FAILED, which this PR does check for
* thanks to streamlining, writing a big bunch of settings by write_from_file subcommand is roughly 6-10 times faster than in the old implementation