### PR TITLE
FileIO speed improvements [ESD-1038]

### DIFF
--- a/piksi_tools/console/update_view.py
+++ b/piksi_tools/console/update_view.py
@@ -687,8 +687,8 @@ class UpdateView(HasTraits):
                 % INDEX_URL)
             return
 
-    def file_transfer_progress_cb(self, arg):
-        new_pcent = float(arg) / float(self.blob_size) * 100
+    def file_transfer_progress_cb(self, offset, repeater):
+        new_pcent = float(offset) / float(self.blob_size) * 100
         if new_pcent - self.pcent_complete > 0.1:
             self.pcent_complete = new_pcent
             self.stream.scrollback_write("{:2.1f} % of {:2.1f} MB transferred.".format(self.pcent_complete, self.blob_size * 1e-6))

--- a/piksi_tools/console/update_view.py
+++ b/piksi_tools/console/update_view.py
@@ -713,7 +713,7 @@ class UpdateView(HasTraits):
         self._write("Transferring image to device...\n\n00.0 of {:2.1f} MB trasnferred".format(self.blob_size * 1e-6))
         try:
             FileIO(self.link).write(
-                "upgrade.image_set.bin",
+                b"upgrade.image_set.bin",
                 self.stm_fw.blob,
                 progress_cb=self.file_transfer_progress_cb)
         except Exception as e:

--- a/piksi_tools/fileio.py
+++ b/piksi_tools/fileio.py
@@ -39,8 +39,8 @@ SBP_FILEIO_WINDOW_SIZE = 1024
 #   at 20 bytes and TCP overhead at 20 bytes.
 SBP_FILEIO_BATCH_SIZE = 32
 
-SBP_FILEIO_TIMEOUT = 1
-MAXIMUM_RETRIES = 20
+SBP_FILEIO_TIMEOUT = 2
+MAXIMUM_RETRIES = 10
 PROGRESS_CB_REDUCTION_FACTOR = 100
 TEXT_ENCODING = 'utf-8'  # used for printing out directory listings and files
 

--- a/piksi_tools/fileio.py
+++ b/piksi_tools/fileio.py
@@ -42,6 +42,7 @@ TEXT_ENCODING = 'utf-8'  # used for printing out directory listings and files
 WAIT_SLEEP_S = 0.001
 CONFIG_REQ_RETRY_MS = 100
 CONFIG_REQ_TIMEOUT_MS = 1000
+READDIR_WAIT_S = 5.0
 
 
 class PendingRequest(object):
@@ -507,7 +508,7 @@ class FileIO(object):
             msg = MsgFileioReadDirReq(
                 sequence=seq, offset=len(files), dirname=dirname)
             self.link(msg)
-            reply = self.link.wait(SBP_MSG_FILEIO_READ_DIR_RESP, timeout=5.0)
+            reply = self.link.wait(SBP_MSG_FILEIO_READ_DIR_RESP, timeout=READDIR_WAIT_S)
             if not reply:
                 raise Exception("Timeout waiting for FILEIO_READ_DIR reply")
             # Why isn't this already decoded?

--- a/piksi_tools/fileio.py
+++ b/piksi_tools/fileio.py
@@ -32,7 +32,7 @@ from sbp.file_io import (SBP_MSG_FILEIO_READ_DIR_RESP,
 from piksi_tools import serial_link
 
 MAX_PAYLOAD_SIZE = 255
-SBP_FILEIO_WINDOW_SIZE = 4096
+SBP_FILEIO_WINDOW_SIZE = 1024
 
 # With SBP packets at 256 bytes, about 5 will fit a max network payload of 1460 bytes
 #   given 1500 as the MTU (maximum transmission unit) for Ethernet with IP overhead

--- a/piksi_tools/fileio.py
+++ b/piksi_tools/fileio.py
@@ -75,7 +75,7 @@ class PendingRequest(object):
         return "PendingRequest(offset=%r,seq=%r,time=%r,tries=%r,index=%r)" % (
             self.message.offset, self.message.sequence, self.time, self.tries, self.index)
 
-    def track(self, pending_req, time, time_expire, tries=0):
+    def track(self, pending_req, time, time_expire):
         """
         Load information about the pending write so that it can be tracked.
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ pyparsing==2.2.0
 pygments==2.2.0
 requests==2.20.0
 six==1.10.0
-sbp==2.4.5
+sbp==2.4.10
 ruamel.yaml==0.15.31
 pre-commit==1.10.3
 setuptools_scm==3.1.0

--- a/tests/test_fileio.py
+++ b/tests/test_fileio.py
@@ -1,0 +1,58 @@
+# -*- python -*-
+
+from piksi_tools.fileio import Time
+
+
+def test_time_repr():
+    t1 = Time(1, 0)
+    assert repr(t1) == "Time(s=1,ms=0)"
+
+
+def test_time_eq():
+    t1 = Time(1, 0)
+    t2 = Time(2, 0)
+    assert t1 != t2
+    t3 = Time(1, 0)
+    assert t1 == t3
+
+
+def test_time_add():
+    t4 = Time(1, 500)
+    t5 = Time(1, 500)
+    assert (t4 + t5) == Time(3, 0)
+
+
+def test_time_ge():
+    t4 = Time(1, 500)
+    t5 = Time(1, 500)
+    assert t4 >= t5
+    t4 += Time(0, 1)
+    assert t4 >= t5
+    t5 += Time(0, 2)
+    assert not (t4 >= t5)
+
+
+def test_time_gt():
+    t4 = Time(1, 500)
+    t5 = Time(1, 500)
+    assert not (t4 > t5)
+    t4 += Time(0, 1)
+    assert (t4 > t5)
+
+
+def test_time():
+    t1 = Time.now()
+    t2 = Time.now()
+    # For epoch time, seconds will "never" be zero
+    assert t1._seconds != 0 and t2._seconds != 0
+    # Could land on 0 milliseconds, but probably never twice
+    assert t1._millis != 0 or t2._millis != 0
+
+
+def test_iter():
+    t1 = Time(1, 500)
+    t2 = Time(1, 505)
+    ls = [Time(1, 501), Time(1, 502), Time(1, 503), Time(1, 504), Time(1, 505)]
+    for iter_t in Time.iter_since(t1, t2):
+        assert ls.pop(0) == iter_t
+    assert len(ls) == 0


### PR DESCRIPTION
## Design notes
This PR adds several improvements to the Python `fileio` client, namely:

+ Bumps the size of the window we use to limit the number of outstanding packets 10x-- this is intended to make the window big enough that we should always have available space to allow us to always have request packets (for writing/reading) in-flight.  We want to avoid waiting in the `_check_pending` function for window space to become available as much as possible.

+  Tries to remove all loops from the fileio client.  Since we bumped the window size we're doing a lot more work per ACK packet that we receive.  To make the fileio client as fast as possible we remove all loops or `O(N)` ops on the number of outstanding requests.  The completion checking in particular now only looks at requests that are due to expire so that during a normal transfer (over TCP) the completion check should have to check zero packets for expiration.

## Testing

Tested on the bench using the `fileio.py` command line client and the console via `upgrade_view.py`.  Basic unit tests were added for the Time class in the `fileio` module.