### PR TITLE
Handle failed connections gracefully [ESD-1034]

### DIFF
--- a/piksi_tools/console/port_chooser.py
+++ b/piksi_tools/console/port_chooser.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python
+# Copyright (C) 2019 Swift Navigation Inc.
+# Contact: Swift Navigation <dev@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+from __future__ import print_function
+
+# UI
+from enable.savage.trait_defs.ui.svg_button import SVGButton
+from traits.api import Bool, Enum, HasTraits, Int, List, Str
+from traitsui.api import EnumEditor, HGroup, Item, Label, Spring, VGroup, View
+
+import piksi_tools.serial_link as s
+from piksi_tools import __version__ as CONSOLE_VERSION
+from piksi_tools.console.utils import resource_filename, icon
+
+
+# If using a device connected to an actual port, then invoke the
+# regular console dialog for port selection
+flow_control_options_list = ['None', 'Hardware RTS/CTS']
+cnx_type_list = ['Serial/USB', 'TCP/IP']
+
+BAUD_LIST = [57600, 115200, 230400, 921600, 1000000]
+
+
+class PortChooser(HasTraits):
+    port = Str(None)
+    ports = List()
+    mode = Enum(cnx_type_list)
+    flow_control = Enum(flow_control_options_list)
+    ip_port = Int(55555)
+    ip_address = Str('192.168.0.222')
+    choose_baud = Bool(True)
+    baudrate = Int()
+    refresh_ports_button = SVGButton(label='',
+                                     tooltip='Refresh Port List',
+                                     filename=resource_filename('console/images/fontawesome/refresh_blue.svg'),
+                                     allow_clipping=False,
+                                     width_padding=4, height_padding=4
+                                     )
+
+    traits_view = View(
+        VGroup(
+            Spring(height=8),
+            HGroup(
+                Spring(width=-2, springy=False),
+                Item(
+                    'mode',
+                    style='custom',
+                    editor=EnumEditor(
+                        values=cnx_type_list, cols=2, format_str='%s'),
+                    show_label=False)),
+            HGroup(
+                VGroup(
+                    Label('Serial Device:'),
+                    HGroup(
+                        Item('port', editor=EnumEditor(name='ports'), show_label=False, springy=True),
+                        Item('refresh_ports_button', show_label=False, padding=0, height=-20, width=-20),
+                    ),
+                ),
+                VGroup(
+                    Label('Baudrate:'),
+                    Item(
+                        'baudrate',
+                        editor=EnumEditor(values=BAUD_LIST),
+                        show_label=False,
+                        visible_when='choose_baud'),
+                    Item(
+                        'baudrate',
+                        show_label=False,
+                        visible_when='not choose_baud',
+                        style='readonly'), ),
+                VGroup(
+                    Label('Flow Control:'),
+                    Item(
+                        'flow_control',
+                        editor=EnumEditor(
+                            values=flow_control_options_list, format_str='%s'),
+                        show_label=False), ),
+                visible_when="mode==\'Serial/USB\'"),
+            HGroup(
+                VGroup(
+                    Label('IP Address:'),
+                    Item(
+                        'ip_address',
+                        label="IP Address",
+                        style='simple',
+                        show_label=False,
+                        height=-24), ),
+                VGroup(
+                    Label('IP Port:'),
+                    Item(
+                        'ip_port',
+                        label="IP Port",
+                        style='simple',
+                        show_label=False,
+                        height=-24), ),
+                Spring(),
+                visible_when="mode==\'TCP/IP\'"), ),
+        buttons=['OK', 'Cancel'],
+        default_button='OK',
+        close_result=False,
+        icon=icon,
+        width=460,
+        title='Swift Console v{0} - Select Interface'.format(CONSOLE_VERSION)
+    )
+
+    def refresh_ports(self):
+        """
+        This method refreshes the port list
+        """
+        try:
+            self.ports = [p for p, _, _ in s.get_ports()]
+        except TypeError:
+            pass
+
+    def _refresh_ports_button_fired(self):
+        self.refresh_ports()
+
+    def __init__(self, baudrate=None):
+        self.refresh_ports()
+        # As default value, use the first city in the list:
+        try:
+            self.port = self.ports[0]
+        except IndexError:
+            pass
+        if baudrate not in BAUD_LIST:
+            self.choose_baud = False
+        self.baudrate = baudrate
+
+
+def get_args_from_port_chooser(args):
+    # Use the gui to get our driver args
+    port_chooser = PortChooser(baudrate=int(args.baud))
+    is_ok = port_chooser.configure_traits()
+    ip_address = port_chooser.ip_address
+    ip_port = port_chooser.ip_port
+    mode = port_chooser.mode
+    args.port = port_chooser.port
+    args.baud = port_chooser.baudrate
+    args.rtscts = port_chooser.flow_control == flow_control_options_list[1]
+
+    # if the user pressed cancel or didn't select anything
+    if not (args.port or (ip_address and ip_port)) or not is_ok:
+        print("No Interface selected!")
+        return None
+
+    # Use TCP/IP if selected from gui
+    if mode == cnx_type_list[1]:
+        args.tcp = True
+        args.port = ip_address + ":" + str(ip_port)
+        print("Using TCP/IP at address %s and port %d" % (ip_address, ip_port))
+    else:
+        args.tcp = False
+
+    return args

--- a/piksi_tools/console/sbp_relay_view.py
+++ b/piksi_tools/console/sbp_relay_view.py
@@ -535,7 +535,7 @@ class SbpRelayView(HasTraits):
         try:
             if (isinstance(self.http_watchdog_thread, threading.Thread) and
                not self.http_watchdog_thread.stopped()):
-                    self.http_watchdog_thread.stop()
+                self.http_watchdog_thread.stop()
             else:
                 print(("Unable to disconnect: Http watchdog thread "
                        "inititalized at {0} and connected since {1} has "

--- a/piksi_tools/fileio.py
+++ b/piksi_tools/fileio.py
@@ -26,7 +26,6 @@ from sbp.file_io import (SBP_MSG_FILEIO_READ_DIR_RESP,
                          MsgFileioReadReq, MsgFileioRemove, MsgFileioWriteReq)
 
 from piksi_tools import serial_link
-from piksi_tools.utils import get_tcp_driver
 
 MAX_PAYLOAD_SIZE = 255
 SBP_FILEIO_WINDOW_SIZE = 100
@@ -426,14 +425,12 @@ def get_args():
     parser.add_argument(
         '-p',
         '--port',
-        default=[serial_link.SERIAL_PORT],
-        nargs=1,
+        default=serial_link.SERIAL_PORT,
         help='specify the serial port to use.')
     parser.add_argument(
         "-b",
         "--baud",
-        default=[serial_link.SERIAL_BAUD],
-        nargs=1,
+        default=serial_link.SERIAL_BAUD,
         help="specify the baud rate to use.")
     parser.add_argument(
         "-t",
@@ -479,12 +476,7 @@ def printable_text_from_device(data):
 
 def main():
     args = get_args()
-    port = args.port[0]
-    baud = args.baud[0]
-    if args.tcp:
-        selected_driver = get_tcp_driver(port)
-    else:
-        selected_driver = serial_link.get_driver(args.ftdi, port, baud)
+    selected_driver = serial_link.get_base_args_driver(args)
 
     # Driver with context
     with selected_driver as driver:

--- a/piksi_tools/sbp_msg_2_csv.py
+++ b/piksi_tools/sbp_msg_2_csv.py
@@ -15,6 +15,7 @@ from sbp.client.drivers.file_driver import FileDriver
 from sbp.table import _SBP_TABLE
 import construct
 
+
 def get_list_of_columns(msgClass, metadata):
     if metadata:
         return ['time'] + msgClass.__slots__
@@ -36,9 +37,9 @@ class MsgExtractor(object):
                 attr = getattr(msg, each)
                 if isinstance(attr, construct.lib.ListContainer):
                     for list_element in attr:
-                      outstringlist.append("{0}".format(list_element))
+                        outstringlist.append("{0}".format(list_element))
                 else:
-                  outstringlist.append("{0}".format(attr))
+                    outstringlist.append("{0}".format(attr))
             except AttributeError:
                 outstringlist.append("{0}".format(data[each]))
         self.outfile.write(",".join(outstringlist) + "\n")

--- a/piksi_tools/utils.py
+++ b/piksi_tools/utils.py
@@ -57,5 +57,4 @@ def get_tcp_driver(host, port=None):
     except socket.timeout:
         raise Exception('TCP connection timed out. Check host: {}'.format(host))
     except Exception as e:
-        import traceback
-        raise Exception('Invalid host and/or port: {0}'.format(traceback.format_exc()))
+        raise Exception('Invalid host and/or port: {}'.format(str(e)))


### PR DESCRIPTION
This PR refactors the console modules startup process to clearly delineate connection attempts from the port chooser dialog. It also centralizes all driver selection around the `serial_link.get_base_args_driver` method.

About 50% of the changes are simple refactoring around that central method for establishing connections based on args from cli or port chooser. The other half is adding the dialog that indicates what may have gone wrong in the connection and falls back to port chooser to allow the user to try again as opposed to restarting the program completely. A typical flow would look like this:

  - User selects some command arguments via CLI
  - Connection fails, a dialog is shown
  - Selecting 'OK' will move to port chooser dialog for retry, 'Cancel' or closing the window will exit the program
  - This will loop back until a successful connection is made, or the user cancels the attempts