### PR TITLE
React to exceptions [ESD-989]

### DIFF
--- a/piksi_tools/console/console.py
+++ b/piksi_tools/console/console.py
@@ -750,7 +750,7 @@ class SwiftConsole(HasTraits):
             import traceback
             traceback.print_exc()
             if self.error:
-                sys.exit(1)
+                os._exit(1)
 
 
 class ShowUsage(HasTraits):

--- a/piksi_tools/console/settings_list.py
+++ b/piksi_tools/console/settings_list.py
@@ -73,3 +73,4 @@ class SettingsList():
         except:  # noqa
             import traceback
             traceback.print_exc()
+            raise

--- a/tox.ini
+++ b/tox.ini
@@ -65,6 +65,7 @@ usedevelop = True
 deps = -rrequirements.txt
        pyinstaller==3.4
        pyside==1.2.4
+       pypiwin32==219
 
 commands = 
         # hack since enable is not packaged correctly

--- a/tox.ini
+++ b/tox.ini
@@ -54,7 +54,7 @@ commands =
         bash tasks/copy_pyqt_to_venv.sh
         # since older pyserial has issues on ubuntu 16.04
         pip install pyserial==3.4
-        pyinstaller -y misc/console.spec
+        pyinstaller --log-level WARN -y misc/console.spec
 
 
 [testenv:pyinstaller-win]
@@ -69,7 +69,7 @@ deps = -rrequirements.txt
 commands = 
         # hack since enable is not packaged correctly
         pip install -r requirements_gui.txt
-        pyinstaller -y misc/console.spec
+        pyinstaller --log-level WARN -y misc/console.spec
 
 [testenv:pyinstaller-macos]
 basepython = python2.7
@@ -84,7 +84,7 @@ commands =
         python misc/hacks/pyside_postinstall.py -install
         # hack since enable is not packaged correctly
         pip install -r requirements_gui.txt
-        pyinstaller -y misc/console.spec
+        pyinstaller --log-level WARN -y misc/console.spec
 
 [testenv:pyinstaller_cmdline_tools-py35]
 basepython = python3.5
@@ -107,7 +107,7 @@ usedevelop = True
 deps = -rrequirements.txt
        pyinstaller==3.4
 commands = 
-       pyinstaller --onefile --distpath ./dist/cmd_line piksi_tools/serial_link.py
-       pyinstaller --onefile --distpath ./dist/cmd_line piksi_tools/settings.py
-       pyinstaller --onefile --distpath ./dist/cmd_line piksi_tools/fileio.py
-       pyinstaller --onefile --distpath ./dist/cmd_line piksi_tools/bootload_v3.py
+       pyinstaller --log-level WARN --onefile --distpath ./dist/cmd_line piksi_tools/serial_link.py
+       pyinstaller --log-level WARN --onefile --distpath ./dist/cmd_line piksi_tools/settings.py
+       pyinstaller --log-level WARN --onefile --distpath ./dist/cmd_line piksi_tools/fileio.py
+       pyinstaller --log-level WARN --onefile --distpath ./dist/cmd_line piksi_tools/bootload_v3.py


### PR DESCRIPTION
Current master Travis build isn't failing on exceptions.

https://swift-nav.atlassian.net/projects/ESD/issues/ESD-989

At least following problems are addressed:
- Exception from malformed YAML wasn't failing the CI build
- pyinstaller INFO message spam hiding WARNINGS and higher
- "win32com module not found" ImportError