### PR TITLE
Fix parse warning/error from ruamel.yaml

### DIFF
--- a/piksi_tools/console/settings.yaml
+++ b/piksi_tools/console/settings.yaml
@@ -1709,7 +1709,7 @@
   default value: 'Static'
   readonly: false
   Description: Ethernet configuration mode.
-  Notes: If DHCP is chosen the IP address will be assigned automatically. Note: The DHCP assigned IP address cannot be viewed under the Settings tab, instead use the Advanced -> Networking Tab and click on 'Refresh Network Status'.
+  Notes: "If DHCP is chosen the IP address will be assigned automatically. Note: The DHCP assigned IP address cannot be viewed under the Settings tab, instead use the Advanced -> Networking Tab and click on 'Refresh Network Status'."
 
 - group: ethernet
   name: ip_address
@@ -1719,7 +1719,7 @@
   default value: '192.168.0.222'
   readonly: false
   Description: The static IP address.
-  Notes: The configured IP address in XXX.XXX.XXX.XXX format. Note: If DHCP is used, the DHCP assigned IP address cannot be viewed under the Settings tab, instead use the Advanced -> Networking Tab and click on 'Refresh Network Status'.
+  Notes: "The configured IP address in XXX.XXX.XXX.XXX format. Note: If DHCP is used, the DHCP assigned IP address cannot be viewed under the Settings tab, instead use the Advanced -> Networking Tab and click on 'Refresh Network Status'."
 
 - group: ethernet
   name: netmask


### PR DESCRIPTION
Fixes this warning/crash from the console with newer versions of ruamel.yaml (which prevent settings help from displaying):

```
Traceback (most recent call last):
  File "/Users/jason/dev/piksi_tools/piksi_tools/console/settings_list.py", line 66, in __init__
    temp_dict = yaml.load(stram)
  File "/Users/jason/dev/piksi_tools/py2/lib/python2.7/site-packages/ruamel/yaml/main.py", line 264, in load
    return constructor.get_single_data()
  File "/Users/jason/dev/piksi_tools/py2/lib/python2.7/site-packages/ruamel/yaml/constructor.py", line 102, in get_single_data
    node = self.composer.get_single_node()
  File "_ruamel_yaml.pyx", line 706, in _ruamel_yaml.CParser.get_single_node (ext/_ruamel_yaml.c:9612)
  File "_ruamel_yaml.pyx", line 724, in _ruamel_yaml.CParser._compose_document (ext/_ruamel_yaml.c:9922)
  File "_ruamel_yaml.pyx", line 773, in _ruamel_yaml.CParser._compose_node (ext/_ruamel_yaml.c:10784)
  File "_ruamel_yaml.pyx", line 850, in _ruamel_yaml.CParser._compose_sequence_node (ext/_ruamel_yaml.c:12011)
  File "_ruamel_yaml.pyx", line 775, in _ruamel_yaml.CParser._compose_node (ext/_ruamel_yaml.c:10814)
  File "_ruamel_yaml.pyx", line 891, in _ruamel_yaml.CParser._compose_mapping_node (ext/_ruamel_yaml.c:12639)
  File "_ruamel_yaml.pyx", line 904, in _ruamel_yaml.CParser._parse_next_event (ext/_ruamel_yaml.c:12818)
ScannerError: mapping values are not allowed in this context
  in "/Users/jason/dev/piksi_tools/piksi_tools/console/settings.yaml", line 1712, column 79
```