### PR TITLE
Allow AppVeyor/PyInstaller to use libsbp from Git [ESD-1038]

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -70,6 +70,20 @@ Upload the console binaries from `dist/` to the
 [AWS S3 bucket](http://downloads.swiftnav.com/swift_console/) and
 update the console version number in the `index.json` there.
 
+# Custom libsbp version
+
+To use a custom libsbp from Git without publishing to PyPI add to following to `requirements.txt`:
+
+```
+git+https://github.com/swift-nav/libsbp.git@<COMMIT_HASH>#subdirectory=python&egg=sbp
+```
+
+Where `<COMMIT_HASH>` is the tip of Git branch you want to use.  Alternately, a local checkout can be installed via:
+
+```
+pip install -e file://$PWD/libsbp#subdirectory=python&egg=sbp
+```
+
 # Contributions
 
 This library is developed internally by Swift Navigation. We welcome

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,8 +12,8 @@ pyparsing==2.2.0
 pygments==2.2.0
 requests==2.20.0
 six==1.10.0
+sbp==2.4.5
 ruamel.yaml==0.15.31
 pre-commit==1.10.3
 setuptools_scm==3.1.0
 enum34==1.1.6
-git+https://github.com/swift-nav/libsbp.git@14ebde8608e72c0f69eefd59f929c1db9e215604#subdirectory=python&egg=sbp

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,8 +12,8 @@ pyparsing==2.2.0
 pygments==2.2.0
 requests==2.20.0
 six==1.10.0
-sbp==2.4.5
 ruamel.yaml==0.15.31
 pre-commit==1.10.3
 setuptools_scm==3.1.0
 enum34==1.1.6
+git+https://github.com/swift-nav/libsbp.git@14ebde8608e72c0f69eefd59f929c1db9e215604#subdirectory=python&egg=sbp

--- a/scripts/build_release.py
+++ b/scripts/build_release.py
@@ -78,25 +78,21 @@ def build_win():
     ])
 
 
-def build_cli_tools_nix():
-    _check_output(['tox', '-e', 'pyinstaller_cmdline_tools-nix'])
-
-
-def build_cli_tools_win():
-    _check_output(['tox', '-e', 'pyinstaller_cmdline_tools-win'])
+def build_cli_tools():
+    _check_output(['tox', '-e', 'pyinstaller_cmdline_tools'])
 
 
 def main():
     plat = sys.platform
     if plat.startswith('linux'):
         build_linux()
-        build_cli_tools_nix()
+        build_cli_tools()
     elif plat.startswith('darwin'):
         build_macos()
-        build_cli_tools_nix()
+        build_cli_tools()
     elif plat.startswith('win'):
         build_win()
-        build_cli_tools_win()
+        build_cli_tools()
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,10 @@
 #!/usr/bin/env python
 
+import re
 import os
 
 from setuptools import setup
 
-from setuptools_scm.git import parse as git_parse
-from setuptools_scm.git import GitWorkdir, _git_parse_describe
-from setuptools_scm.git import DEFAULT_DESCRIBE
-from setuptools_scm.config import Configuration
-from setuptools_scm.utils import do_ex, trace, has_command
-from setuptools_scm.version import meta
 
 CLASSIFIERS = [
     'Intended Audience :: Developers',
@@ -54,16 +49,25 @@ PACKAGE_DATA = {
 }
 
 
-
-def myparse(
-        root, describe_command=DEFAULT_DESCRIBE, config=None):
+def scmtools_parse(root,
+                   describe_command=None,
+                   config=None):
     """
     rewriting of setuptools_scm.git.parse method to remove -branch string
     from any tags.  This library is clearly not designed for people to adjust
-    its function so I had to lift entire function from Aug 8 master with SHA 
+    its function so I had to lift entire function from Aug 8 master with SHA
     a91b40c99ea9bfc4289272285f17e1d43c243b76
-
     """
+
+    from setuptools_scm.git import GitWorkdir, _git_parse_describe
+    from setuptools_scm.config import Configuration
+    from setuptools_scm.utils import has_command
+    from setuptools_scm.version import meta
+
+    if describe_command is None:
+        from setuptools_scm.git import DEFAULT_DESCRIBE
+        describe_command = DEFAULT_DESCRIBE
+
     if not config:
         config = Configuration(root=root)
 
@@ -96,7 +100,7 @@ def myparse(
         branch = wd.get_branch()
         if number:
             return meta(
-                tag.replace('-branch',''),
+                tag.replace('-branch', ''),
                 config=config,
                 distance=number,
                 node=node,
@@ -106,30 +110,43 @@ def myparse(
         else:
             return meta(tag.replace('-branch', ''), config=config, node=node, dirty=dirty, branch=branch)
 
-cwd = os.path.abspath(os.path.dirname(__file__))
-with open(cwd + '/README.rst') as f:
-    readme = f.read()
 
-with open(cwd + '/requirements.txt') as f:
-    INSTALL_REQUIRES = [i.strip() for i in f.readlines()]
+if __name__ == '__main__':
 
-setup(
-    name='piksi_tools',
-    description='Python tools for the Piksi GNSS receiver.',
-    long_description=readme,
-    use_scm_version={
-        'write_to': 'piksi_tools/_version.py',
-        'parse': myparse
-    },
-    setup_requires=['setuptools_scm'],
-    author='Swift Navigation',
-    author_email='dev@swiftnav.com',
-    url='https://github.com/swift-nav/piksi_tools',
-    classifiers=CLASSIFIERS,
-    packages=PACKAGES,
-    package_data=PACKAGE_DATA,
-    platforms=PLATFORMS,
-    install_requires=INSTALL_REQUIRES,
-    include_package_data=True,
-    use_2to3=False,
-    zip_safe=False)
+    cwd = os.path.abspath(os.path.dirname(__file__))
+
+    with open(cwd + '/README.rst') as f:
+        readme = f.read()
+
+    with open(cwd + '/requirements.txt') as fp:
+
+        INSTALL_REQUIRES = [L.strip() for L in fp if not L.startswith('git+')]
+
+        def transform(link):
+            link = link.strip()
+            spl = re.split('[&#]', link)
+            return str.join('#', spl)
+
+        DEPENDENCY_LINKS = [transform(L) for L in fp if L.startswith('git+')]
+
+    setup(
+        name='piksi_tools',
+        description='Python tools for the Piksi GNSS receiver.',
+        long_description=readme,
+        use_scm_version={
+            'write_to': 'piksi_tools/_version.py',
+            'parse': scmtools_parse
+        },
+        setup_requires=['setuptools_scm'],
+        author='Swift Navigation',
+        author_email='dev@swiftnav.com',
+        url='https://github.com/swift-nav/piksi_tools',
+        classifiers=CLASSIFIERS,
+        packages=PACKAGES,
+        package_data=PACKAGE_DATA,
+        platforms=PLATFORMS,
+        install_requires=INSTALL_REQUIRES,
+        dependency_links=DEPENDENCY_LINKS,
+        include_package_data=True,
+        use_2to3=False,
+        zip_safe=False)


### PR DESCRIPTION
This changes make `piksi_tools` tolerant of a `libsbp` version that is fetched from a Git repository by commit hash rather than PyPI-- this change allows our CI infrastructure to pick up development versions of libsbp that are paired with development work in the console.