### PR TITLE
Adjust default value for obs divisor to match FW

### DIFF
--- a/piksi_tools/console/settings.yaml
+++ b/piksi_tools/console/settings.yaml
@@ -354,7 +354,7 @@
   expert: false
   type: integer
   units: N/A
-  default value: '2'
+  default value: '10'
   readonly: false
   enumerated possible values:
   Description: Integer divisor of solution frequency for which the observations will


### PR DESCRIPTION
Seems FW has already been defaulted to 1hz out - https://github.com/swift-nav/piksi_firmware_private/blob/master/src/calc/calc_pvt_me.c#L72


this adjust the console documentation to match