### PR TITLE
imu_view: use invoke_later to schedule GUI updates

### DIFF
--- a/piksi_tools/console/baseline_view.py
+++ b/piksi_tools/console/baseline_view.py
@@ -15,7 +15,6 @@ import threading
 from collections import deque
 
 import numpy as np
-from pyface.api import GUI
 from chaco.api import ArrayPlotData, Plot
 from chaco.tools.api import PanTool, ZoomTool
 from enable.api import ComponentEditor
@@ -37,7 +36,7 @@ from piksi_tools.console.utils import (
     datetime_2_str, get_mode, log_time_strings, mode_dict)
 from piksi_tools.utils import sopen
 from .utils import resource_filename
-from .gui_utils import GUI_UPDATE_PERIOD, STALE_DATA_PERIOD
+from .gui_utils import GUI_UPDATE_PERIOD, STALE_DATA_PERIOD, UpdateScheduler
 
 PLOT_HISTORY_MAX = 1000
 
@@ -363,7 +362,7 @@ class BaselineView(HasTraits):
             self.list_lock.release()
 
         if time.time() - self.last_plot_update_time > GUI_UPDATE_PERIOD:
-            GUI.invoke_later(self._solution_draw)
+            self.update_scheduler.schedule_update('_solution_draw', self._solution_draw)
 
     def _solution_draw(self):
         self.list_lock.acquire()
@@ -527,3 +526,4 @@ class BaselineView(HasTraits):
                                SBP_MSG_AGE_CORRECTIONS)
 
         self.python_console_cmds = {'baseline': self}
+        self.update_scheduler = UpdateScheduler()

--- a/piksi_tools/console/imu_view.py
+++ b/piksi_tools/console/imu_view.py
@@ -14,6 +14,7 @@ from __future__ import print_function
 
 import numpy as np
 import time
+from pyface.api import GUI
 from chaco.api import ArrayPlotData, Plot
 from chaco.tools.api import LegendTool
 from enable.api import ComponentEditor
@@ -62,14 +63,29 @@ class IMUView(HasTraits):
         )
     )
 
-    def imu_set_data(self):
+    def update_plot(self):
+        self.update_scheduled = False
         self.last_plot_update_time = time.time()
-        self.plot_data.set_data('acc_x', self.acc[:, 0])
-        self.plot_data.set_data('acc_y', self.acc[:, 1])
-        self.plot_data.set_data('acc_z', self.acc[:, 2])
-        self.plot_data.set_data('gyr_x', self.gyro[:, 0])
-        self.plot_data.set_data('gyr_y', self.gyro[:, 1])
-        self.plot_data.set_data('gyr_z', self.gyro[:, 2])
+        self.plot_data.set_data('acc_x', self.acc_x)
+        self.plot_data.set_data('acc_y', self.acc_y)
+        self.plot_data.set_data('acc_z', self.acc_z)
+        self.plot_data.set_data('gyr_x', self.gyro_x)
+        self.plot_data.set_data('gyr_y', self.gyro_y)
+        self.plot_data.set_data('gyr_z', self.gyro_z)
+
+    def imu_set_data(self):
+        if time.time() - self.last_plot_update_time < GUI_UPDATE_PERIOD:
+            return
+        if self.update_scheduled:
+            return
+        if self.imu_conf is not None:
+            acc_range = self.imu_conf & 0xF
+            sf = 2. ** (acc_range + 1) / 2. ** 15
+            self.rms_acc_x = sf * np.sqrt(np.mean(np.square(self.acc_x)))
+            self.rms_acc_y = sf * np.sqrt(np.mean(np.square(self.acc_y)))
+            self.rms_acc_z = sf * np.sqrt(np.mean(np.square(self.acc_z)))
+        self.update_scheduled = True
+        GUI.invoke_later(self.update_plot)
 
     def imu_aux_callback(self, sbp_msg, **metadata):
         if sbp_msg.imu_type == 0:
@@ -79,25 +95,30 @@ class IMUView(HasTraits):
             print("IMU type %d not known" % sbp_msg.imu_type)
 
     def imu_raw_callback(self, sbp_msg, **metadata):
-        self.acc[:-1, :] = self.acc[1:, :]
-        self.gyro[:-1, :] = self.gyro[1:, :]
-        self.acc[-1] = (sbp_msg.acc_x, sbp_msg.acc_y, sbp_msg.acc_z)
-        self.gyro[-1] = (sbp_msg.gyr_x, sbp_msg.gyr_y, sbp_msg.gyr_z)
-
-        if time.time() - self.last_plot_update_time > GUI_UPDATE_PERIOD:
-            self.imu_set_data()
-            if self.imu_conf is not None:
-                acc_range = self.imu_conf & 0xF
-                sf = 2. ** (acc_range + 1) / 2. ** 15
-                self.rms_acc_x = sf * np.sqrt(np.mean(np.square(self.acc[:, 0])))
-                self.rms_acc_y = sf * np.sqrt(np.mean(np.square(self.acc[:, 1])))
-                self.rms_acc_z = sf * np.sqrt(np.mean(np.square(self.acc[:, 2])))
+        memoryview(self.acc_x)[:-1] = memoryview(self.acc_x)[1:]
+        memoryview(self.acc_y)[:-1] = memoryview(self.acc_y)[1:]
+        memoryview(self.acc_z)[:-1] = memoryview(self.acc_z)[1:]
+        memoryview(self.gyro_x)[:-1] = memoryview(self.gyro_x)[1:]
+        memoryview(self.gyro_y)[:-1] = memoryview(self.gyro_y)[1:]
+        memoryview(self.gyro_z)[:-1] = memoryview(self.gyro_z)[1:]
+        self.acc_x[-1] = sbp_msg.acc_x
+        self.acc_y[-1] = sbp_msg.acc_y
+        self.acc_z[-1] = sbp_msg.acc_z
+        self.gyro_x[-1] = sbp_msg.gyr_x
+        self.gyro_y[-1] = sbp_msg.gyr_y
+        self.gyro_z[-1] = sbp_msg.gyr_z
+        self.imu_set_data()
 
     def __init__(self, link):
         super(IMUView, self).__init__()
 
-        self.acc = np.zeros((NUM_POINTS, 3))
-        self.gyro = np.zeros((NUM_POINTS, 3))
+        self.acc_x = np.zeros(NUM_POINTS)
+        self.acc_y = np.zeros(NUM_POINTS)
+        self.acc_z = np.zeros(NUM_POINTS)
+        self.gyro_x = np.zeros(NUM_POINTS)
+        self.gyro_y = np.zeros(NUM_POINTS)
+        self.gyro_z = np.zeros(NUM_POINTS)
+
         self.last_plot_update_time = 0
 
         self.plot_data = ArrayPlotData(
@@ -146,4 +167,7 @@ class IMUView(HasTraits):
         self.link = link
         self.link.add_callback(self.imu_raw_callback, SBP_MSG_IMU_RAW)
         self.link.add_callback(self.imu_aux_callback, SBP_MSG_IMU_AUX)
+
         self.python_console_cmds = {'track': self}
+
+        self.update_scheduled = False

--- a/piksi_tools/console/solution_view.py
+++ b/piksi_tools/console/solution_view.py
@@ -19,7 +19,6 @@ import threading
 from collections import deque
 
 import numpy as np
-from pyface.api import GUI
 from chaco.api import ArrayPlotData, Plot
 from chaco.tools.api import PanTool, ZoomTool
 from enable.api import ComponentEditor
@@ -44,7 +43,7 @@ from piksi_tools.console.utils import (
     mode_dict)
 from piksi_tools.utils import sopen
 from .utils import resource_filename
-from .gui_utils import GUI_UPDATE_PERIOD, STALE_DATA_PERIOD
+from .gui_utils import GUI_UPDATE_PERIOD, STALE_DATA_PERIOD, UpdateScheduler
 
 PLOT_HISTORY_MAX = 1000
 
@@ -411,7 +410,7 @@ class SolutionView(HasTraits):
         # Updating array plot data is not thread safe, so we have to fire an event
         # and have the GUI thread do it
         if time.time() - self.last_plot_update_time > GUI_UPDATE_PERIOD:
-            GUI.invoke_later(self._solution_draw)
+            self.update_scheduler.schedule_update('_solution_draw', self._solution_draw)
 
     def _display_units_changed(self):
         # we store current extents of plot and current scalefactlrs
@@ -879,7 +878,5 @@ class SolutionView(HasTraits):
         self.nsec = 0
         self.meters_per_lat = None
         self.meters_per_lon = None
-
-        self.python_console_cmds = {
-            'solution': self,
-        }
+        self.python_console_cmds = {'solution': self}
+        self.update_scheduler = UpdateScheduler()

--- a/piksi_tools/console/spectrum_analyzer_view.py
+++ b/piksi_tools/console/spectrum_analyzer_view.py
@@ -13,11 +13,12 @@ import struct
 import numpy as np
 from chaco.api import ArrayPlotData, Plot
 from enable.api import ComponentEditor
-from pyface.api import GUI
 from sbp.client.util.fftmonitor import FFTMonitor
 from sbp.piksi import SBP_MSG_SPECAN, SBP_MSG_SPECAN_DEP
 from traits.api import Dict, HasTraits, Instance, Str
 from traitsui.api import EnumEditor, Item, View, HGroup, Spring
+
+from .gui_utils import UpdateScheduler
 
 # How many points are in each FFT?
 NUM_POINTS = 512
@@ -120,7 +121,7 @@ class SpectrumAnalyzerView(HasTraits):
             self.fftmonitor.clear_ffts()
             self.most_recent_complete_data['frequencies'] = most_recent_fft['frequencies']
             self.most_recent_complete_data['amplitudes'] = most_recent_fft['amplitudes']
-            GUI.invoke_later(self.update_plot)
+            self.update_scheduler.schedule_update('update_plot', self.update_plot)
 
     def update_plot(self):
         most_recent_fft = self.most_recent_complete_data
@@ -163,3 +164,5 @@ class SpectrumAnalyzerView(HasTraits):
         self.plot_data.set_data('amplitude', [0])
         self.plot.plot(
             ('frequency', 'amplitude'), type='line', name='spectrum')
+
+        self.update_scheduler = UpdateScheduler()


### PR DESCRIPTION
Also, split the multi-dimensional arrays for (x,y,z) accelerometer and gyro data into separate x, y and z arrays so we can avoid a bunch of data copies when updating the data.

This is the pattern that's used in the tracking view and seems to have better memory usage and performance characteristics when the IMU view is not visible.  This also makes all touches to the GUI happen on the GUI thread.