### PR TITLE
setuptools_scm version output now includes 'v' so stop adding it [ESD-1195]

### DIFF
--- a/piksi_tools/console/console.py
+++ b/piksi_tools/console/console.py
@@ -113,7 +113,7 @@ def get_args():
     return parser
 
 
-CONSOLE_TITLE = 'Swift Console v' + CONSOLE_VERSION
+CONSOLE_TITLE = 'Swift Console ' + CONSOLE_VERSION
 
 
 class ConsoleHandler(Handler):

--- a/piksi_tools/console/port_chooser.py
+++ b/piksi_tools/console/port_chooser.py
@@ -108,7 +108,7 @@ class PortChooser(HasTraits):
         close_result=False,
         icon=icon,
         width=460,
-        title='Swift Console v{0} - Select Interface'.format(CONSOLE_VERSION)
+        title='Swift Console {0} - Select Interface'.format(CONSOLE_VERSION)
     )
 
     def refresh_ports(self):

--- a/piksi_tools/console/update_view.py
+++ b/piksi_tools/console/update_view.py
@@ -178,7 +178,7 @@ class UpdateView(HasTraits):
     newest_stm_vers = String('Downloading Latest Firmware info...')
     piksi_nap_vers = String('Waiting for Piksi to send settings...')
     newest_nap_vers = String('Downloading Latest Firmware info...')
-    local_console_vers = String('v' + CONSOLE_VERSION)
+    local_console_vers = String(CONSOLE_VERSION)
     newest_console_vers = String('Downloading Latest Console info...')
     download_directory_label = String('Firmware Download Directory:')
 
@@ -586,7 +586,7 @@ class UpdateView(HasTraits):
                         "Please visit http://support.swiftnav.com to\n" + \
                         "download the latest version.\n\n" + \
                         "Local Console Version :\n\t" + \
-                        "v" + CONSOLE_VERSION + \
+                        CONSOLE_VERSION + \
                         "\nLatest Console Version :\n\t" + \
                         self.update_dl.index[self.piksi_hw_rev]['console']['version'] + "\n"
                 else:

--- a/scripts/build_release.py
+++ b/scripts/build_release.py
@@ -39,7 +39,7 @@ def build(env):
 def build_linux():
     import tarfile
     out_pyi, version = build('pyinstaller-linux')
-    out = os.path.join(os.getcwd(), os.path.join('dist', 'swift_console_v{}_linux'.format(version)))
+    out = os.path.join(os.getcwd(), os.path.join('dist', 'swift_console_{}_linux'.format(version)))
     maybe_remove(out)
     shutil.move(out_pyi, out)
 
@@ -57,7 +57,7 @@ def build_macos():
         'sudo',
         os.path.join(os.getcwd(), os.path.join('misc',
                      'create-dmg-installer.sh')),
-        'swift_console_v{}_macos.dmg'.format(version)
+        'swift_console_{}_macos.dmg'.format(version)
     ])
 
 
@@ -75,7 +75,7 @@ def build_win():
 
     check_call([
         nsis,
-        '-XOutfile ../dist/swift_console_v{}_windows.exe'.format(version),
+        '-XOutfile ../dist/swift_console_{}_windows.exe'.format(version),
         'misc/swift_console.nsi'
     ])
 


### PR DESCRIPTION
~WIP - testing build output artifacts for now~

seems to do the trick. moving forward I believe the assumption should be that the `v` in `v2.1.17` etc., is part of the `CONSOLE_VERSION` that comes from `_version.py`. I don't know exactly when/why this changed but I think a missing `v` is better than `vv` so this PR simply errs on the side of removing all artificially added `v`'s