### PR TITLE
Update RAIM Disable decription

### DIFF
--- a/piksi_tools/console/settings.yaml
+++ b/piksi_tools/console/settings.yaml
@@ -465,7 +465,7 @@
   readonly: false
   enumerated possible values: True,False
   Description: Receiver Autonomous Integrity Monitoring.
-  Notes: If True, RAIM checks will not be performed.
+  Notes: If True, RAIM checks will not be performed on observation output.
 
 - group: solution
   name: send_heading


### PR DESCRIPTION
Disabling RAIM only turns it off on the ME (controlling observation output) and not in starling today
