### PR TITLE
Fix some float precision differences between python 2 and 3 [ESD-1231]

### DIFF
--- a/piksi_tools/console/baseline_view.py
+++ b/piksi_tools/console/baseline_view.py
@@ -328,11 +328,11 @@ class BaselineView(HasTraits):
                     tutc, float(secutc))))
                 table.append(('UTC Src', self.utc_source))
 
-            table.append(('N', soln.n))
-            table.append(('E', soln.e))
-            table.append(('D', soln.d))
-            table.append(('Horiz Acc', soln.h_accuracy))
-            table.append(('Vert Acc', soln.v_accuracy))
+            table.append(('N', "{:.12g}".format(soln.n)))
+            table.append(('E', "{:.12g}".format(soln.e)))
+            table.append(('D', "{:.12g}".format(soln.d)))
+            table.append(('Horiz Acc', "{:.12g}".format(soln.h_accuracy)))
+            table.append(('Vert Acc', "{:.12g}".format(soln.v_accuracy)))
             table.append(('Dist.', "{0:.3f}".format(dist)))
 
             table.append(('Sats Used', soln.n_sats))

--- a/piksi_tools/console/solution_view.py
+++ b/piksi_tools/console/solution_view.py
@@ -382,11 +382,11 @@ class SolutionView(HasTraits):
                 pos_table.append(('UTC Src', EMPTY_STR))
 
             pos_table.append(('Sats Used', soln.n_sats))
-            pos_table.append(('Lat', soln.lat))
-            pos_table.append(('Lng', soln.lon))
+            pos_table.append(('Lat', "{:.12g}".format(soln.lat)))
+            pos_table.append(('Lng', "{:.12g}".format(soln.lon)))
             pos_table.append(('Height', "{0:.3f}".format(soln.height)))
-            pos_table.append(('Horiz Acc', soln.h_accuracy))
-            pos_table.append(('Vert Acc', soln.v_accuracy))
+            pos_table.append(('Horiz Acc', "{:.12g}".format(soln.h_accuracy)))
+            pos_table.append(('Vert Acc', "{:.12g}".format(soln.v_accuracy)))
 
         pos_table.append(('Pos Flags', '0x%03x' % soln.flags))
         pos_table.append(('INS Used', '{}'.format(self.ins_used)))


### PR DESCRIPTION
* by default python 3 can print floats to strings with a greater amount
  of decimals than python 2, making a difference and producing
  clutter in some tabs

To be backported to v2.3.0-release.