### PR TITLE
(Experimental) Force fixed table row heights [ESD-1232]

### DIFF
--- a/piksi_tools/console/baseline_view.py
+++ b/piksi_tools/console/baseline_view.py
@@ -27,10 +27,10 @@ from sbp.navigation import (
 from sbp.orientation import SBP_MSG_BASELINE_HEADING, MsgBaselineHeading
 from sbp.piksi import MsgResetFilters
 from traits.api import Bool, Button, Float, Dict, File, HasTraits, Instance, List
-from traitsui.api import HGroup, HSplit, Item, TabularEditor, VGroup, View
+from traitsui.api import HGroup, HSplit, Item, VGroup, View
 from traitsui.tabular_adapter import TabularAdapter
 
-from piksi_tools.console.gui_utils import plot_square_axes
+from piksi_tools.console.gui_utils import plot_square_axes, PiksiTabularEditor
 from piksi_tools.console.utils import (
     DGNSS_MODE, EMPTY_STR, FIXED_MODE, FLOAT_MODE, color_dict,
     datetime_2_str, get_mode, log_time_strings, mode_dict)
@@ -107,7 +107,7 @@ class BaselineView(HasTraits):
             Item(
                 'table',
                 style='readonly',
-                editor=TabularEditor(adapter=SimpleAdapter()),
+                editor=PiksiTabularEditor(adapter=SimpleAdapter()),
                 show_label=False,
                 width=0.3),
             VGroup(

--- a/piksi_tools/console/console.py
+++ b/piksi_tools/console/console.py
@@ -21,6 +21,9 @@ import time
 # Shut chaco up for now
 import warnings
 
+# Needs to be before qt init by traitsui imports
+from piksi_tools.console import windows_scaling # noqa
+
 import sbp.client as sbpc
 from enable.savage.trait_defs.ui.svg_button import SVGButton
 from pyface.image_resource import ImageResource

--- a/piksi_tools/console/gui_utils.py
+++ b/piksi_tools/console/gui_utils.py
@@ -12,8 +12,9 @@ import numpy as np
 
 from pyface.api import GUI
 
-from traits.api import Bool, HasTraits, List
-from traitsui.api import HGroup, VGroup, Item, TextEditor
+from traits.api import Bool, HasTraits, List, Int
+from traitsui.api import HGroup, VGroup, Item, TextEditor, TabularEditor
+from traitsui.qt4.tabular_editor import _TableView
 
 from piksi_tools.console.utils import SUPPORTED_CODES, GUI_CODES, code_to_str
 
@@ -130,3 +131,44 @@ class CodeFiltered(HasTraits):
                         visible_when="{} in received_codes".format(code)))
             hgroup.content.append(vgroup)
         return hgroup
+
+
+class PiksiTabularEditor(TabularEditor):
+    """Extends traitsui.api.TabularEditor by allowing setting a fixed row height
+
+       Limitations:
+       * only supports Qt backends
+       * only effective at initialization (later changes have no effect)"""
+
+    row_height = Int(19)
+
+    def initTableView(self, *args, **kwds):
+        """Overrides normal traitsui table widget init to adjust properties"""
+        table_view = _TableView(*args, **kwds)
+        if self.row_height > 0:
+            table_view.verticalHeader().setDefaultSectionSize(self.row_height)
+        return table_view
+
+    def simple_editor(self, ui, object, name, description, parent):
+        """Hooks into traitsui table widget init"""
+        editor = super(PiksiTabularEditor, self).simple_editor(ui, object, name, description, parent)
+        editor.widget_factory = self.initTableView
+        return editor
+
+    def custom_editor(self, ui, object, name, description, parent):
+        """Hooks into traitsui table widget init"""
+        editor = super(PiksiTabularEditor, self).custom_editor(ui, object, name, description, parent)
+        editor.widget_factory = self.initTableView
+        return editor
+
+    def readonly_editor(self, ui, object, name, description, parent):
+        """Hooks into traitsui table widget init"""
+        editor = super(PiksiTabularEditor, self).readonly_editor(ui, object, name, description, parent)
+        editor.widget_factory = self.initTableView
+        return editor
+
+    def text_editor(self, ui, object, name, description, parent):
+        """Hooks into traitsui table widget init"""
+        editor = super(PiksiTabularEditor, self).text_editor(ui, object, name, description, parent)
+        editor.widget_factory = self.initTableView
+        return editor

--- a/piksi_tools/console/observation_view.py
+++ b/piksi_tools/console/observation_view.py
@@ -17,13 +17,13 @@ import time
 from sbp.observation import (SBP_MSG_OBS, SBP_MSG_OBS_DEP_A, SBP_MSG_OBS_DEP_B,
                              SBP_MSG_OBS_DEP_C)
 from traits.api import Dict, Float, Int, List, Str
-from traitsui.api import HGroup, Item, UItem, Spring, TabularEditor, VGroup, View
+from traitsui.api import HGroup, Item, UItem, Spring, VGroup, View
 from traitsui.tabular_adapter import TabularAdapter
 
 from piksi_tools.console.gui_utils import CodeFiltered, UpdateScheduler
 from piksi_tools.console.utils import (
     EMPTY_STR, GUI_CODES, SUPPORTED_CODES, code_is_gps, code_to_str)
-from piksi_tools.console.gui_utils import GUI_UPDATE_PERIOD
+from piksi_tools.console.gui_utils import GUI_UPDATE_PERIOD, PiksiTabularEditor
 
 
 class SimpleAdapter(TabularAdapter):
@@ -115,7 +115,7 @@ class ObservationView(CodeFiltered):
                 Item(
                     'traits_obs_table_list',
                     style='readonly',
-                    editor=TabularEditor(adapter=SimpleAdapter()),
+                    editor=PiksiTabularEditor(adapter=SimpleAdapter()),
                     show_label=False),
                 label=self.name,
                 padding=0,

--- a/piksi_tools/console/output_list.py
+++ b/piksi_tools/console/output_list.py
@@ -19,10 +19,11 @@ import time
 from pyface.api import GUI
 from traits.api import (Bool, Enum, Float, Font, HasTraits, Int, List,
                         Property, Str, Trait)
-from traitsui.api import TabularEditor, UItem, View
+from traitsui.api import UItem, View
 from traitsui.tabular_adapter import TabularAdapter
 
 from piksi_tools.utils import sopen
+from piksi_tools.console.gui_utils import PiksiTabularEditor
 
 # These levels are identical to sys.log levels
 LOG_EMERG = 0  # system is unusable
@@ -312,7 +313,7 @@ class OutputList(HasTraits):
         view = \
             View(
                 UItem('filtered_list',
-                      editor=TabularEditor(adapter=LogItemOutputListAdapter(), editable=False,
-                                           vertical_lines=False, horizontal_lines=False))
+                      editor=PiksiTabularEditor(adapter=LogItemOutputListAdapter(), editable=False,
+                                                vertical_lines=False, horizontal_lines=False))
             )
         return view

--- a/piksi_tools/console/sbp_relay_view.py
+++ b/piksi_tools/console/sbp_relay_view.py
@@ -18,7 +18,7 @@ from sbp.piksi import (SBP_MSG_NETWORK_STATE_RESP, MsgNetworkStateReq)
 from traits.api import Bool, Button, Enum, HasTraits, Int, String, List, \
     Instance
 from traitsui.api import (HGroup, Item, TextEditor, UItem, VGroup,
-                          View, spring, TabularEditor)
+                          View, spring)
 from traitsui.tabular_adapter import TabularAdapter
 
 from piksi_tools.console.callback_prompt import CallbackPrompt, close_button
@@ -26,6 +26,7 @@ from piksi_tools.console.gui_utils import MultilineTextEditor
 from piksi_tools.console.cellmodem_view import CellModemView
 from traits.etsconfig.api import ETSConfig
 from .utils import resource_filename, sizeof_fmt
+from piksi_tools.console.gui_utils import PiksiTabularEditor
 
 if ETSConfig.toolkit != 'null':
     from enable.savage.trait_defs.ui.svg_button import SVGButton
@@ -120,8 +121,8 @@ class SbpRelayView(HasTraits):
                           Item(
                               '_network_info',
                               style='readonly',
-                              editor=TabularEditor(
-                                  adapter=SimpleNetworkAdapter()),
+                              editor=PiksiTabularEditor(
+                                  adapter=SimpleNetworkAdapter(), row_height=17),
                               show_label=False, ),
                           Item(
                               'network_refresh_button', show_label=False,

--- a/piksi_tools/console/settings_view.py
+++ b/piksi_tools/console/settings_view.py
@@ -24,11 +24,11 @@ from sbp.system import SBP_MSG_STARTUP
 from traits.api import (Bool, Color, Constant, Float, Font, HasTraits,
                         Instance, List, Property, Str, Undefined)
 from traits.etsconfig.api import ETSConfig
-from traitsui.api import (EnumEditor, HGroup, HSplit, Item, TabularEditor,
+from traitsui.api import (EnumEditor, HGroup, HSplit, Item,
                           TextEditor, UItem, VGroup, View)
 from traitsui.tabular_adapter import TabularAdapter
 import piksi_tools.console.callback_prompt as prompt
-from piksi_tools.console.gui_utils import MultilineTextEditor
+from piksi_tools.console.gui_utils import MultilineTextEditor, PiksiTabularEditor
 from piksi_tools.console.utils import swift_path
 from pyface.api import FileDialog, OK
 
@@ -363,7 +363,7 @@ class SettingsView(HasTraits):
         HSplit(
             Item(
                 'settings_list',
-                editor=TabularEditor(
+                editor=PiksiTabularEditor(
                     adapter=SimpleAdapter(),
                     editable_labels=False,
                     auto_update=True,
@@ -457,7 +457,7 @@ class SettingsView(HasTraits):
             # from objbrowser import browse
             # browse(confirm_prompt)
             confirm_prompt.view.content.content[0].content.append(
-                Item("settings_list", editor=TabularEditor(
+                Item("settings_list", editor=PiksiTabularEditor(
                     adapter=SimpleChangeAdapter(),
                     editable_labels=False,
                     auto_update=True,

--- a/piksi_tools/console/solution_view.py
+++ b/piksi_tools/console/solution_view.py
@@ -32,11 +32,11 @@ from sbp.navigation import (
     MsgVelNEDDepA)
 from traits.api import (Bool, Dict, File, HasTraits, Instance, Int, Float, List,
                         Str, Enum)
-from traitsui.api import (HGroup, HSplit, Item, TabularEditor, TextEditor,
+from traitsui.api import (HGroup, HSplit, Item, TextEditor,
                           VGroup, View)
 from traitsui.tabular_adapter import TabularAdapter
 
-from piksi_tools.console.gui_utils import MultilineTextEditor, plot_square_axes
+from piksi_tools.console.gui_utils import MultilineTextEditor, plot_square_axes, PiksiTabularEditor
 from piksi_tools.console.utils import (
     DGNSS_MODE, EMPTY_STR, FIXED_MODE, FLOAT_MODE, SBAS_MODE, DR_MODE,
     SPP_MODE, color_dict, datetime_2_str, get_mode, log_time_strings,
@@ -156,7 +156,7 @@ class SolutionView(HasTraits):
                 Item(
                     'table',
                     style='readonly',
-                    editor=TabularEditor(adapter=SimpleAdapter()),
+                    editor=PiksiTabularEditor(adapter=SimpleAdapter()),
                     show_label=False,
                     width=0.3),
                 Item(

--- a/piksi_tools/console/system_monitor_view.py
+++ b/piksi_tools/console/system_monitor_view.py
@@ -17,10 +17,11 @@ from sbp.piksi import (SBP_MSG_THREAD_STATE,
 from sbp.system import SBP_MSG_HEARTBEAT, SBP_MSG_CSAC_TELEMETRY, SBP_MSG_CSAC_TELEMETRY_LABELS
 from traits.api import Dict, HasTraits, Int, Float, List, Bool
 from traits.etsconfig.api import ETSConfig
-from traitsui.api import HGroup, Item, TabularEditor, VGroup, View
+from traitsui.api import HGroup, Item, VGroup, View
 from traitsui.tabular_adapter import TabularAdapter
 
 from .utils import resource_filename
+from piksi_tools.console.gui_utils import PiksiTabularEditor
 
 if ETSConfig.toolkit != 'null':
     from enable.savage.trait_defs.ui.svg_button import SVGButton
@@ -72,7 +73,7 @@ class SystemMonitorView(HasTraits):
             Item(
                 '_threads_table_list',
                 style='readonly',
-                editor=TabularEditor(adapter=SimpleAdapter()),
+                editor=PiksiTabularEditor(adapter=SimpleAdapter()),
                 show_label=False,
                 width=0.85, ),
             HGroup(
@@ -147,7 +148,7 @@ class SystemMonitorView(HasTraits):
                     Item(
                         '_csac_telem_list',
                         style='readonly',
-                        editor=TabularEditor(adapter=SimpleCSACAdapter()),
+                        editor=PiksiTabularEditor(adapter=SimpleCSACAdapter()),
                         show_label=False),
                     show_border=True,
                     label="Metrics",

--- a/piksi_tools/console/windows_scaling.py
+++ b/piksi_tools/console/windows_scaling.py
@@ -19,6 +19,17 @@ import pyface.qt
 #
 # Ideally would become unnecessary one day when all components, plots included,
 # would properly work in a high dpi environment.
+
+if '--print-dpi' in sys.argv:
+    from PyQt5 import QtWidgets
+
+    app = QtWidgets.QApplication([])
+    dpi_list = [screen.logicalDotsPerInch() for screen in app.screens()]
+    max_dpi = max(dpi_list)
+
+    print(max_dpi, end="")
+    sys.exit(0)
+
 if sys.platform == "win32" and pyface.qt.qt_api.lower() in ['pyqt5', 'pyside2']:
     prog_str = b"""\
 from PyQt5 import QtWidgets
@@ -32,7 +43,7 @@ print(max_dpi, end="")
     # initializing the application to use this Windows scaling mechanism is
     # only possible before initializing the QApplication for the first time,
     # so the dpi query, which also uses Qt, is done in a separate process
-    helper_proc = subprocess.Popen([sys.executable, "-u", "-"],
+    helper_proc = subprocess.Popen([sys.executable, "-u", "-", '--print-dpi'],
                                    stdin=subprocess.PIPE,
                                    stdout=subprocess.PIPE,
                                    stderr=subprocess.STDOUT)

--- a/piksi_tools/console/windows_scaling.py
+++ b/piksi_tools/console/windows_scaling.py
@@ -1,0 +1,43 @@
+# Copyright (C) 2019 Swift Navigation Inc.
+# Contact: engineering@swiftnav.com
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+import sys
+import subprocess
+import pyface.qt
+
+# A hack to use Windows legacy scaling mode when started on a high dpi screen
+# using Qt5. Otherwise the layout would change somewhat, and plot legend fonts
+# would become too small. The downside can be some blurriness due to scaling.
+# See https://doc.qt.io/qt-5/highdpi.html
+#
+# Ideally would become unnecessary one day when all components, plots included,
+# would properly work in a high dpi environment.
+if sys.platform == "win32" and pyface.qt.qt_api.lower() in ['pyqt5', 'pyside2']:
+    prog_str = b"""\
+from PyQt5 import QtWidgets
+
+app = QtWidgets.QApplication([])
+dpi_list = [screen.logicalDotsPerInch() for screen in app.screens()]
+max_dpi = max(dpi_list)
+
+print(max_dpi, end="")
+"""
+    # initializing the application to use this Windows scaling mechanism is
+    # only possible before initializing the QApplication for the first time,
+    # so the dpi query, which also uses Qt, is done in a separate process
+    helper_proc = subprocess.Popen([sys.executable, "-u", "-"],
+                                   stdin=subprocess.PIPE,
+                                   stdout=subprocess.PIPE,
+                                   stderr=subprocess.STDOUT)
+    output, _ = helper_proc.communicate(input=prog_str)
+    dpi = float(output)
+    high_dpi = (dpi > 96.0)  # 96 is the standard windows logical dpi nowadays
+    if high_dpi:
+        sys.argv.extend(["-platform", "windows:dpiawareness=0"])


### PR DESCRIPTION
TraitsUI's TabularEditor uses a QTableView internally with a Qt backend.
Between Qt 4.8 and 5.10, the QHeaderView.minimumSectionSize(), which
is used by TraitsUI to set table row heights, has changed on Windows.
This changes the appearance of, e.g., Settings and Log view by
making the individual rows slightly taller.

This experimental commit hacks the row heights back to their Qt4
values.

It's currently unknown to me whether the Qt-side change is a feature or a bug, could be either. Reviewers of this PR should consider whether it's a worthwhile tweak or not.