### PR TITLE
Fix computed doppler in obs. tab (master) [ESD-1276]

### DIFF
--- a/piksi_tools/console/observation_view.py
+++ b/piksi_tools/console/observation_view.py
@@ -154,7 +154,7 @@ class ObservationView(CodeFiltered):
             self.gps_week = wn
             self.prev_obs_total = total
             self.prev_obs_count = 0
-            self.old_cp = self.new_cp
+            self.old_cp = dict(self.new_cp)
             self.new_cp.clear()
             self.incoming_obs.clear()
 


### PR DESCRIPTION
It was broken by 65e75e42572235c24ff9bd3d432e6ee21d97f42d where a Traits dict was changed to a normal Python dict. The Traits dict does a copy on assignment while the normal Python dict doesn't, and thus clearing the original dict didn't clear the copied Traits dict but it does erroneously clear both normal Python dictionary references.

This is a forward-port of #1026 