### PR TITLE
Tweak the "Refresh settings from device" button [ESD-1268]

### DIFF
--- a/piksi_tools/console/gui_utils.py
+++ b/piksi_tools/console/gui_utils.py
@@ -14,6 +14,8 @@ from pyface.api import GUI
 
 from traits.api import Bool, HasTraits, List
 from traitsui.api import HGroup, VGroup, Item, TextEditor
+from traitsui.basic_editor_factory import BasicEditorFactory
+import traitsui.qt4.boolean_editor
 
 from piksi_tools.console.utils import SUPPORTED_CODES, GUI_CODES, code_to_str
 
@@ -130,3 +132,17 @@ class CodeFiltered(HasTraits):
                         visible_when="{} in received_codes".format(code)))
             hgroup.content.append(vgroup)
         return hgroup
+
+
+class _PiksiBooleanEditor(traitsui.qt4.boolean_editor.SimpleEditor):
+    def init(self, parent):
+        super(_PiksiBooleanEditor, self).init(parent)
+        self.control.setText(self.item.get_label(self.ui))
+
+
+class PiksiBooleanEditor(BasicEditorFactory):
+    """Extends TraitsUI's bool editor
+
+       by making the UI item's label part of the toggle button (editor).
+       This enables toggling it by clicking on the text, too, as in normal Qt."""
+    klass = _PiksiBooleanEditor

--- a/piksi_tools/console/settings_view.py
+++ b/piksi_tools/console/settings_view.py
@@ -34,6 +34,7 @@ from pyface.api import FileDialog, OK
 
 from .settings_list import SettingsList
 from .utils import resource_filename
+from .gui_utils import PiksiBooleanEditor
 
 from libsettings import Settings, SettingsWriteResponseCodes
 
@@ -384,9 +385,9 @@ class SettingsView(HasTraits):
                         visible_when='show_auto_survey'),
                 ),
                 HGroup(
-                    Item('settings_read_button', show_label=False),
-                    Item('expert', show_label=False),
-                    Item('', label="Show Advanced\nSettings", padding=0),
+                    UItem('settings_read_button'),
+                    UItem('expert', label="Show Advanced\nSettings",
+                          editor=PiksiBooleanEditor()),
                 ),
                 Item('selected_setting', style='custom', show_label=False),
             ),

--- a/piksi_tools/console/settings_view.py
+++ b/piksi_tools/console/settings_view.py
@@ -328,10 +328,12 @@ class SettingsView(HasTraits):
         width=20,
         height=20)
     settings_read_button = SVGButton(
+        label='Refresh settings\nfrom device',
         tooltip='Reload settings from Piksi',
         filename=resource_filename('console/images/fontawesome/refresh.svg'),
-        allow_clipping=False,
-        width_padding=4, height_padding=4)
+        orientation='horizontal',
+        width=20,
+        height=20)
     settings_save_button = SVGButton(
         label='Save to\nDevice',
         tooltip='Save settings to persistent storage on device.',
@@ -382,9 +384,7 @@ class SettingsView(HasTraits):
                         visible_when='show_auto_survey'),
                 ),
                 HGroup(
-                    Item('settings_read_button', show_label=False,
-                         padding=0, height=-20, width=-20),
-                    Item('', label="Refresh settings\nfrom device", padding=0),
+                    Item('settings_read_button', show_label=False),
                     Item('expert', show_label=False),
                     Item('', label="Show Advanced\nSettings", padding=0),
                 ),

--- a/requirements_gui.txt
+++ b/requirements_gui.txt
@@ -1,5 +1,5 @@
-# fixes a memory leak. TODO: update to 4.7.3 when released
-git+git://github.com/swift-nav/enable@fe0a66630da725afb739b41137ed8c6e09b08f71#egg=enable
+# several fixes compared to enable v. 4.7.2. TODO: update to 4.7.3 when released
+git+git://github.com/enthought/enable@77b23977ad5486328ec59f6bc14cbbdc8b53d7dd#egg=enable
 
 chaco==4.7.2
 traits==4.6.0 


### PR DESCRIPTION
The previously separate button text moved into a button label to be
similar with the other buttons.

There is a bug in enable's SVGButton that horizontal layout doesn't
work (probably the reason why this button was originally configured
separately for button and text). I made a separate PR to fix that at https://github.com/enthought/enable/pull/338 and they already approved & merged it. I updated the swift fork's master to reflect this but didn't yet update requirements_gui.txt. Wondering whether that dependency should be updated just for master or for both master and v.2.3.0-release...