### PR TITLE
Use monotonic time to prevent plotting artifacts [ESD-1269]

### DIFF
--- a/piksi_tools/console/baseline_view.py
+++ b/piksi_tools/console/baseline_view.py
@@ -11,6 +11,7 @@
 import datetime
 import os
 import time
+from monotonic import monotonic
 import threading
 from collections import deque
 
@@ -315,7 +316,7 @@ class BaselineView(HasTraits):
             table.append(('Heading', EMPTY_STR))
             table.append(('Corr. Age [s]', EMPTY_STR))
         else:
-            self.last_btime_update = time.time()
+            self.last_btime_update = monotonic()
             if self.week is not None:
                 table.append(('GPS Week', str(self.week)))
             table.append(('GPS TOW', "{:.3f}".format(tow)))
@@ -361,12 +362,12 @@ class BaselineView(HasTraits):
             self._append_empty_sln_data(soln)
             self.list_lock.release()
 
-        if time.time() - self.last_plot_update_time > GUI_UPDATE_PERIOD:
+        if monotonic() - self.last_plot_update_time > GUI_UPDATE_PERIOD:
             self.update_scheduler.schedule_update('_solution_draw', self._solution_draw)
 
     def _solution_draw(self):
         self.list_lock.acquire()
-        current_time = time.time()
+        current_time = monotonic()
         self.last_plot_update_time = current_time
         pending_draw_modes = self.pending_draw_modes
         current_mode = pending_draw_modes[-1] if len(pending_draw_modes) > 0 else None

--- a/piksi_tools/console/imu_view.py
+++ b/piksi_tools/console/imu_view.py
@@ -13,7 +13,7 @@
 from __future__ import print_function
 
 import numpy as np
-import time
+from monotonic import monotonic
 from chaco.api import ArrayPlotData, Plot
 from chaco.tools.api import LegendTool
 from enable.api import ComponentEditor
@@ -63,7 +63,7 @@ class IMUView(HasTraits):
     )
 
     def update_plot(self):
-        self.last_plot_update_time = time.time()
+        self.last_plot_update_time = monotonic()
         self.plot_data.set_data('acc_x', self.acc_x)
         self.plot_data.set_data('acc_y', self.acc_y)
         self.plot_data.set_data('acc_z', self.acc_z)
@@ -72,7 +72,7 @@ class IMUView(HasTraits):
         self.plot_data.set_data('gyr_z', self.gyro_z)
 
     def imu_set_data(self):
-        if time.time() - self.last_plot_update_time < GUI_UPDATE_PERIOD:
+        if monotonic() - self.last_plot_update_time < GUI_UPDATE_PERIOD:
             return
         if self.imu_conf is not None:
             acc_range = self.imu_conf & 0xF

--- a/piksi_tools/console/mag_view.py
+++ b/piksi_tools/console/mag_view.py
@@ -13,7 +13,7 @@
 from __future__ import print_function
 
 import numpy as np
-import time
+from monotonic import monotonic
 
 from chaco.api import ArrayPlotData, Plot
 from chaco.tools.api import LegendTool
@@ -53,7 +53,7 @@ class MagView(HasTraits):
     )
 
     def mag_set_data(self):
-        self.last_plot_update_time = time.time()
+        self.last_plot_update_time = monotonic()
         min_data = np.min(self.mag)
         max_data = np.max(self.mag)
         padding = (max_data - min_data) / 4.0
@@ -72,7 +72,7 @@ class MagView(HasTraits):
         self.mag[-1] = (sbp_msg.mag_x,
                         sbp_msg.mag_y,
                         sbp_msg.mag_z)
-        if time.time() - self.last_plot_update_time > GUI_UPDATE_PERIOD:
+        if monotonic() - self.last_plot_update_time > GUI_UPDATE_PERIOD:
             self.mag_set_data()
 
     def __init__(self, link):

--- a/piksi_tools/console/observation_view.py
+++ b/piksi_tools/console/observation_view.py
@@ -12,8 +12,7 @@
 
 from __future__ import print_function
 
-import time
-
+from monotonic import monotonic
 from sbp.observation import (SBP_MSG_OBS, SBP_MSG_OBS_DEP_A, SBP_MSG_OBS_DEP_B,
                              SBP_MSG_OBS_DEP_C)
 from traits.api import Dict, Float, Int, List, Str
@@ -279,10 +278,10 @@ class ObservationView(CodeFiltered):
 
         if (count == total - 1):
             # this is here to let GUI catch up to real time if required
-            if time.time() - self.last_table_update_time > GUI_UPDATE_PERIOD:
+            if monotonic() - self.last_table_update_time > GUI_UPDATE_PERIOD:
                 self.update_scheduler.schedule_update('update_obs', self.update_obs, self.incoming_obs.copy())
                 self.last_table_update_tow = self.gps_tow
-                self.last_table_update_time = time.time()
+                self.last_table_update_time = monotonic()
         return
 
     def __init__(self, link, name='Local', relay=False, dirname=None):

--- a/piksi_tools/console/solution_view.py
+++ b/piksi_tools/console/solution_view.py
@@ -15,6 +15,7 @@ import datetime
 import math
 import os
 import time
+from monotonic import monotonic
 import threading
 from collections import deque
 
@@ -364,7 +365,7 @@ class SolutionView(HasTraits):
             pos_table.append(('Horiz Acc', EMPTY_STR))
             pos_table.append(('Vert Acc', EMPTY_STR))
         else:
-            self.last_stime_update = time.time()
+            self.last_stime_update = monotonic()
 
             if self.week is not None:
                 pos_table.append(('GPS Week', str(self.week)))
@@ -409,7 +410,7 @@ class SolutionView(HasTraits):
         # setup_plot variables
         # Updating array plot data is not thread safe, so we have to fire an event
         # and have the GUI thread do it
-        if time.time() - self.last_plot_update_time > GUI_UPDATE_PERIOD:
+        if monotonic() - self.last_plot_update_time > GUI_UPDATE_PERIOD:
             self.update_scheduler.schedule_update('_solution_draw', self._solution_draw)
 
     def _display_units_changed(self):
@@ -480,7 +481,7 @@ class SolutionView(HasTraits):
 
     def _solution_draw(self):
         self.list_lock.acquire()
-        current_time = time.time()
+        current_time = monotonic()
         self.last_plot_update_time = current_time
         pending_draw_modes = self.pending_draw_modes
         current_mode = pending_draw_modes[-1] if len(pending_draw_modes) > 0 else None

--- a/piksi_tools/console/tracking_view.py
+++ b/piksi_tools/console/tracking_view.py
@@ -10,9 +10,10 @@
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 
-import time
-from collections import defaultdict, deque
+import monotonic
 import threading
+
+from collections import defaultdict, deque
 from chaco.api import ArrayPlotData, Plot
 from chaco.tools.api import LegendTool
 from enable.api import ComponentEditor
@@ -142,8 +143,8 @@ class TrackingView(CodeFiltered):
     def measurement_state_callback(self, sbp_msg, **metadata):
         with self.CN0_lock:
             codes_that_came = []
-            t = time.time() - self.t_init
-            self.time.append(t)
+            the_time = monotonic.monotonic() - self.t_init
+            self.time.append(the_time)
             # first we loop over all the SIDs / channel keys we have stored and set 0 in for CN0
             for i, s in enumerate(sbp_msg.states):
                 if code_is_glo(s.mesid.code):
@@ -160,7 +161,7 @@ class TrackingView(CodeFiltered):
                 codes_that_came.append(key)
                 if s.cn0 != 0:
                     self.CN0_dict[key].append(s.cn0 / 4.0)
-                    self.CN0_age[key] = t
+                    self.CN0_age[key] = the_time
                 received_code_list = getattr(self, "received_codes", [])
                 if s.mesid.code not in received_code_list:
                     received_code_list.append(s.mesid.code)
@@ -168,13 +169,13 @@ class TrackingView(CodeFiltered):
             for key, cno_array in list(self.CN0_dict.items()):
                 if key not in codes_that_came:
                     cno_array.append(0)
-            self.clean_cn0(t)
+            self.clean_cn0(the_time)
         self.update_scheduler.schedule_update('update_plot', self.update_plot)
 
     def tracking_state_callback(self, sbp_msg, **metadata):
         with self.CN0_lock:
             codes_that_came = []
-            t = time.time() - self.t_init
+            t = monotonic.monotonic() - self.t_init
             self.time.append(t)
             # first we loop over all the SIDs / channel keys we have stored and set 0 in for CN0
             # for each SID, an array of size MAX PLOT with the history of CN0's stored
@@ -257,7 +258,7 @@ class TrackingView(CodeFiltered):
 
     def __init__(self, link):
         super(TrackingView, self).__init__()
-        self.t_init = time.time()
+        self.t_init = monotonic.monotonic()
         self.time = deque([x * 1 / TRK_RATE for x in range(-NUM_POINTS, 0, 1)], maxlen=NUM_POINTS)
         self.CN0_lock = threading.Lock()
         self.CN0_dict = defaultdict(lambda: deque([0] * NUM_POINTS, maxlen=NUM_POINTS))

--- a/piksi_tools/fileio.py
+++ b/piksi_tools/fileio.py
@@ -684,7 +684,7 @@ def printable_text_from_device(data):
 
 def mk_progress_cb(file_length):
 
-    time_last = [time.time()]
+    time_last = [Time.now()]
     offset_last = [0]
 
     b_to_mb = 1024 * 1024.0
@@ -710,12 +710,12 @@ def mk_progress_cb(file_length):
             return previous_avg[0]
 
     def the_callback(offset, repeater):
-        time_current = time.time()
+        time_current = Time.now()
         offset_delta = offset - offset_last[0]
         time_delta = time_current - time_last[0]
         percent_done = 100 * (offset / float(file_length))
         mb_confirmed = offset / b_to_mb
-        speed_kbs = offset_delta / time_delta / 1024
+        speed_kbs = offset_delta / time_delta.to_float() / 1024
         rolling_avg = compute_rolling_average(speed_kbs)
         fmt_str = "\r[{:02.02f}% ({:.02f}/{:.02f} MB) at {:.02f} kB/s ({:0.02f}% retried)]"
         percent_retried = 100 * (repeater.total_retries / repeater.total_sends)

--- a/piksi_tools/fileio.py
+++ b/piksi_tools/fileio.py
@@ -31,6 +31,7 @@ from sbp.file_io import (SBP_MSG_FILEIO_READ_DIR_RESP, SBP_MSG_FILEIO_READ_RESP,
                          MsgFileioConfigReq, MsgFileioConfigResp)
 
 from piksi_tools import serial_link
+from piksi_tools.utils import Time
 
 MAX_PAYLOAD_SIZE = 255
 SBP_FILEIO_WINDOW_SIZE = 100
@@ -96,61 +97,6 @@ class PendingRequest(object):
         self.time = retry_time
         self.time_expire = new_expire_time
         return self
-
-
-class Time(object):
-    """
-    Time object with millisecond resolution.  Used to inspect
-    request expiration times.
-    """
-
-    __slots__ = ["_seconds", "_millis"]
-
-    def __init__(self, seconds=0, millis=0):
-        self._seconds = seconds
-        self._millis = millis
-
-    @classmethod
-    def now(cls):
-        now = time.time()
-        return Time(int(now), int((now * 1000) % 1000))
-
-    @classmethod
-    def iter_since(cls, last, now):
-        """
-        Iterate time slices since the `last` time given up to (and including)
-        the `now` time but not including the `last` time.
-        """
-        increment = Time(0, 1)
-        next_time = last
-        while not next_time >= now:
-            next_time += increment
-            yield next_time
-
-    def __hash__(self):
-        return hash((self._seconds, self._millis))
-
-    def __repr__(self):
-        return "Time(s=%r,ms=%r)" % (self._seconds, self._millis)
-
-    def __add__(a, b):
-        new_time = (1000 * a._seconds) + (1000 * b._seconds) + a._millis + b._millis
-        return Time(seconds=(new_time // 1000), millis=(new_time % 1000))
-
-    def __eq__(a, b):
-        return a._seconds == b._seconds and a._millis == b._millis
-
-    def __ge__(a, b):
-        if a == b:
-            return True
-        return a > b
-
-    def __gt__(a, b):
-        if a._seconds < b._seconds:
-            return False
-        if a._seconds == b._seconds:
-            return a._millis > b._millis
-        return True
 
 
 class SelectiveRepeater(object):

--- a/piksi_tools/serial_link.py
+++ b/piksi_tools/serial_link.py
@@ -17,6 +17,7 @@ from __future__ import print_function
 import os
 import sys
 import time
+from monotonic import monotonic
 
 import serial.tools.list_ports
 from sbp.client import Forwarder, Framer, Handler
@@ -275,9 +276,9 @@ def run(args, link):
         link(MsgReset(flags=0))
     try:
         if args.timeout is not None:
-            expire = time.time() + float(args.timeout)
+            expire = monotonic() + float(args.timeout)
         while True:
-            if timeout is None or time.time() < expire:
+            if timeout is None or monotonic() < expire:
                 # Wait forever until the user presses Ctrl-C
                 time.sleep(1)
             else:

--- a/piksi_tools/utils.py
+++ b/piksi_tools/utils.py
@@ -13,9 +13,11 @@ from __future__ import print_function
 
 import errno
 import os
+import socket
+
+import monotonic
 
 from sbp.client.drivers.network_drivers import TCPDriver
-import socket
 
 
 def wrap_sbp_dict(data_dict, timestamp):
@@ -59,3 +61,81 @@ def get_tcp_driver(host, port=None):
         raise Exception('TCP connection timed out. Check host: {}'.format(host))
     except Exception as e:
         raise Exception('Invalid host and/or port: {}'.format(str(e)))
+
+
+class Time(object):
+    """
+    Time object with millisecond resolution.  Used to inspect
+    request expiration times.
+    """
+
+    __slots__ = ["_seconds", "_millis"]
+
+    def __init__(self, seconds=0, millis=0):
+        self._seconds = seconds
+        self._millis = millis
+
+    @staticmethod
+    def now():
+        now = monotonic.monotonic()
+        return Time.from_float(now)
+
+    @staticmethod
+    def from_float(seconds):
+        return Time(int(seconds), int((seconds * 1000) % 1000))
+
+    @staticmethod
+    def iter_since(last, now):
+        """
+        Iterate time slices since the `last` time given up to (and including)
+        the `now` time but not including the `last` time.
+        """
+        increment = Time(0, 1)
+        next_time = last
+        while not next_time >= now:
+            next_time += increment
+            yield next_time
+
+    def to_float(self):
+        return self._seconds + (self._millis / 1000)
+
+    def __hash__(self):
+        return hash((self._seconds, self._millis))
+
+    def __repr__(self):
+        return "Time(s=%r,ms=%r)" % (self._seconds, self._millis)
+
+    def __add__(a, b):
+        new_time = (1000 * a._seconds) + (1000 * b._seconds) + a._millis + b._millis
+        return Time(seconds=(new_time // 1000), millis=(new_time % 1000))
+
+    def __sub__(a, b):
+        new_time = (1000 * a._seconds) - (1000 * b._seconds) - a._millis - b._millis
+        return Time(seconds=(new_time // 1000), millis=(new_time % 1000))
+
+    def __eq__(a, b):
+        return a._seconds == b._seconds and a._millis == b._millis
+
+    def __ge__(a, b):
+        if a == b:
+            return True
+        return a > b
+
+    def __gt__(a, b):
+        if a._seconds < b._seconds:
+            return False
+        if a._seconds == b._seconds:
+            return a._millis > b._millis
+        return True
+
+    def __le__(a, b):
+        if a == b:
+            return True
+        return a < b
+
+    def __lt__(a, b):
+        if a._seconds > b._seconds:
+            return False
+        if a._seconds == b._seconds:
+            return a._millis < b._millis
+        return True

--- a/piksi_tools/utils.py
+++ b/piksi_tools/utils.py
@@ -14,7 +14,6 @@ from __future__ import print_function
 import errno
 import os
 import socket
-
 import monotonic
 
 from sbp.client.drivers.network_drivers import TCPDriver

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ ruamel.yaml==0.15.87
 setuptools_scm==3.1.0
 enum34==1.1.6
 libsettings==0.1.11
+monotonic==1.5

--- a/tests/test_fileio.py
+++ b/tests/test_fileio.py
@@ -1,6 +1,6 @@
 # -*- python -*-
 
-from piksi_tools.fileio import Time
+from piksi_tools.utils import Time
 
 
 def test_time_repr():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -40,6 +40,23 @@ def test_time_gt():
     assert (t4 > t5)
 
 
+def test_time_le():
+    t1 = Time(1, 500)
+    t2 = Time(1, 500)
+    assert t1 <= t2
+    t2 += Time(0, 1)
+    assert t1 <= t2
+    t1 += Time(0, 2)
+    assert not (t1 <= t2)
+
+
+def test_time_lt():
+    t1 = Time(1, 500)
+    t2 = Time(1, 500)
+    assert not (t1 > t2)
+    t1 += Time(0, 1)
+    assert (t2 < t1)
+
 def test_time():
     t1 = Time.now()
     t2 = Time.now()


### PR DESCRIPTION
Decrementing system time causes plotting artifacts in tracking view. This can be fixed by switching to a monotonic clock  that never goes backwards. This is a wrap-up of https://github.com/swift-nav/piksi_tools/commit/3afede840b6e87fe33fd7867a2346200ca997c5c.