### PR TITLE
Remove a broken optimization to fix computed doppler [ESD-1276]

### DIFF
--- a/piksi_tools/console/observation_view.py
+++ b/piksi_tools/console/observation_view.py
@@ -170,10 +170,7 @@ class ObservationView(CodeFiltered):
             return
         else:
             self.prev_obs_count = count
-        # Don't bother updating anything except the TOW faster than 2Hz
-        tow_diff = self.gps_tow - self.last_table_update_tow
-        if tow_diff > 0 and tow_diff < 0.5:
-            return
+
         # Save this packet
         # See sbp_piksi.h for format
         for o in sbp_msg.obs:


### PR DESCRIPTION
Otherwise local computed doppler is missing when setting (soln freq) / (output every n obs) is high. The optimization was also otherwise broken in that it didn't update TOW as advertised.

Also, UI updates are nowadays separately scheduled so this doesn't directly affect UI update frequency.

IMO it is best to remove this broken optimization. If that is not acceptable, it's also possible to keep & fix  it, but it would be more complex (keeping track of collecting computed doppler), and IMO this was/is a slightly dangerous optimization, could cause also other subtle bugs.

I'll backport this to v2.3.0-release upon approval of this PR.