### PR TITLE
(Experimental) Add an alternatively scaled windows shortcut, variant 4 [ESD-1232]

### DIFF
--- a/misc/swift_console.nsi
+++ b/misc/swift_console.nsi
@@ -48,6 +48,7 @@ inst:
   ; Now create shortcuts
   CreateDirectory "$SMPROGRAMS\Swift Navigation"
   CreateShortCut "$SMPROGRAMS\Swift Navigation\Swift Console.lnk" "$INSTDIR\console.exe"
+  CreateShortCut "$SMPROGRAMS\Swift Navigation\Swift Console, scaled for high DPI displays.lnk" "$INSTDIR\console.exe" "--scale"
   CreateShortCut "$SMPROGRAMS\Swift Navigation\Uninstall.lnk" "$INSTDIR\Uninstall.exe"
 
   ;create desktop shortcut

--- a/piksi_tools/console/console.py
+++ b/piksi_tools/console/console.py
@@ -21,6 +21,9 @@ import time
 # Shut chaco up for now
 import warnings
 
+# needs to be before enable imports
+from piksi_tools.console.scaling import scaled_size
+
 import sbp.client as sbpc
 from enable.savage.trait_defs.ui.svg_button import SVGButton
 from pyface.image_resource import ImageResource
@@ -91,6 +94,10 @@ def get_args():
         '--log-console',
         action='store_true',
         help="Log console stdout/err to file.")
+    parser.add_argument(
+        '--scale',
+        action='store_true',
+        help="Scale the Console window if running on a high-DPI monitor. Primarily meant for Windows.")
     parser.add_argument(
         '-h',
         '--help',
@@ -207,14 +214,14 @@ class SwiftConsole(HasTraits):
         toggle=True,
         filename=resource_filename('console/images/iconic/pause.svg'),
         toggle_filename=resource_filename('console/images/iconic/play.svg'),
-        width=8,
-        height=8)
+        width=scaled_size(8),
+        height=scaled_size(8))
     clear_button = SVGButton(
         label='',
         tooltip='Clear console buffer',
         filename=resource_filename('console/images/iconic/x.svg'),
-        width=8,
-        height=8)
+        width=scaled_size(8),
+        height=scaled_size(8))
 
     view = View(
         VSplit(
@@ -258,41 +265,41 @@ class SwiftConsole(HasTraits):
                             'paused_button',
                             show_label=False,
                             padding=0,
-                            width=8,
-                            height=8),
+                            width=scaled_size(8),
+                            height=scaled_size(8)),
                         Item(
                             'clear_button',
                             show_label=False,
-                            width=8,
-                            height=8),
+                            width=scaled_size(8),
+                            height=scaled_size(8)),
                         Item('', label='Console Log', emphasized=True),
                         Item(
                             'csv_logging_button',
                             emphasized=True,
                             show_label=False,
-                            width=12,
-                            height=-30,
+                            width=scaled_size(12),
+                            height=scaled_size(-30),
                             padding=0),
                         Item(
                             'json_logging_button',
                             emphasized=True,
                             show_label=False,
-                            width=12,
-                            height=-30,
+                            width=scaled_size(12),
+                            height=scaled_size(-30),
                             padding=0),
                         Item(
                             'directory_name',
                             show_label=False,
                             springy=True,
                             tooltip='Choose location for file logs. Default is home/SwiftNav.',
-                            height=-25,
+                            height=scaled_size(-25),
                             enabled_when='not(json_logging or csv_logging)',
                             editor_args={'auto_set': True}),
                         UItem(
                             'log_level_filter',
                             style='simple',
                             padding=0,
-                            height=8,
+                            height=scaled_size(8),
                             show_label=True,
                             tooltip='Show log levels up to and including the selected level of severity.\nThe CONSOLE log level is always visible.'
                         ), ),
@@ -300,7 +307,7 @@ class SwiftConsole(HasTraits):
                         'console_output',
                         style='custom',
                         editor=InstanceEditor(),
-                        height=125,
+                        height=scaled_size(125),
                         show_label=False,
                         full_size=True), ),
                 HGroup(
@@ -354,8 +361,8 @@ class SwiftConsole(HasTraits):
                         'cnx_icon',
                         show_label=False,
                         padding=0,
-                        width=8,
-                        height=8,
+                        width=scaled_size(8),
+                        height=scaled_size(8),
                         visible_when='solid_connection',
                         springy=False,
                         editor=ImageEditor(
@@ -366,8 +373,8 @@ class SwiftConsole(HasTraits):
                         'cnx_icon',
                         show_label=False,
                         padding=0,
-                        width=8,
-                        height=8,
+                        width=scaled_size(8),
+                        height=scaled_size(8),
                         visible_when='not solid_connection',
                         springy=False,
                         editor=ImageEditor(
@@ -379,8 +386,8 @@ class SwiftConsole(HasTraits):
                 Spring(height=1, springy=False), ), ),
         icon=icon,
         resizable=True,
-        width=800,
-        height=600,
+        width=scaled_size(800),
+        height=scaled_size(600),
         handler=ConsoleHandler(),
         title=CONSOLE_TITLE)
 

--- a/piksi_tools/console/scaling.py
+++ b/piksi_tools/console/scaling.py
@@ -1,0 +1,30 @@
+# Copyright (C) 2019 Swift Navigation Inc.
+# Contact: engineering@swiftnav.com
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+import sys
+from traits.etsconfig.api import ETSConfig
+from pyface.qt import QtGui
+
+if '--scale' in sys.argv:
+    ETSConfig._kiva_backend = 'qpainter'
+
+
+def scaled_size(default_size):
+    '''Scale a pixel size based on monitor's DPI.
+
+       Primarily meant for Windows. If the DPI is 96, no scaling is done.'''
+    if '--scale' in sys.argv:
+        # this is before actual argument parsing
+        primary_screen = QtGui.QApplication.primaryScreen()
+        dpi = primary_screen.logicalDotsPerInch()
+        size_after_scaling = int(default_size * dpi / 96.0)
+        return size_after_scaling
+    else:
+        return default_size

--- a/piksi_tools/console/tracking_view.py
+++ b/piksi_tools/console/tracking_view.py
@@ -284,7 +284,7 @@ class TrackingView(CodeFiltered):
         self.plot.legend.visible = True
         self.plot.legend.align = 'll'
         self.plot.legend.line_spacing = 1
-        self.plot.legend.font = 'monospace 8'
+        self.plot.legend.font = 'monospace 6'
         self.plot.legend.draw_layer = 'overlay'
         self.plot.legend.tools.append(
             LegendTool(self.plot.legend, drag_button="right"))


### PR DESCRIPTION
A prototype of scaling Console properly on high DPI displays, mainly in Windows, a variant of https://github.com/swift-nav/piksi_tools/pull/1040 . This is just a prototype, though, and doesn't scale all components correctly. The main change in this one is to use a different enable backend to render fonts in correct size, but this seems to cause some layout problems with fonts.

There are multiple alternatives, to be tested out and seen which one works best across different devices:
* https://github.com/swift-nav/piksi_tools/pull/1036: Qt/Windows scaling toggleable by using a different Console shortcut (in Windows' start menu). This may cause some blurriness but makes sizes close to the old state, and this way plot legends etc. readable on high dpi displays.
* https://github.com/swift-nav/piksi_tools/pull/1039: the same as https://github.com/swift-nav/piksi_tools/pull/1036 except using a different Qt scaling parameter
* https://github.com/swift-nav/piksi_tools/pull/1040: a prototype of doing scaling "properly" without top-level scaling, theoretically providing the best rendering quality, but is far from being finished. One idea could be to merge https://github.com/swift-nav/piksi_tools/pull/1036 or https://github.com/swift-nav/piksi_tools/pull/1039 and let https://github.com/swift-nav/piksi_tools/pull/1040 be a prototype for future continuation work
* https://github.com/swift-nav/piksi_tools/pull/1041: about the same as https://github.com/swift-nav/piksi_tools/pull/1040 except using a different enable backend (changes chart font rendering)