### PR TITLE
Update enable to fix zooming by mouse wheel in win/linux (master) [ESD-1235]

### DIFF
--- a/requirements_gui.txt
+++ b/requirements_gui.txt
@@ -1,5 +1,5 @@
 # several fixes ahead of enable & chaco v. 4.7.2. TODO: update to 4.7.3 when released
-git+git://github.com/enthought/enable@77b23977ad5486328ec59f6bc14cbbdc8b53d7dd#egg=enable
+git+git://github.com/enthought/enable@d225b6f4a3516f84c6a68f1369c885f7190a18d6#egg=enable
 git+git://github.com/enthought/chaco@14c5539248b25ab4c737c5f74523c71d95587731#egg=chaco
 
 traits==4.6.0 


### PR DESCRIPTION
See https://github.com/enthought/enable/pull/340.

* only affects win/linux usage with pyqt5
* mac already worked and is unchanged

Backporting to v2.3.0-release in https://github.com/swift-nav/piksi_tools/pull/1044.