### PR TITLE
[ESD-1222] Remove blocking check for smoothpose when upgrading

### DIFF
--- a/piksi_tools/console/settings_view.py
+++ b/piksi_tools/console/settings_view.py
@@ -448,8 +448,7 @@ class SettingsView(HasTraits):
         Returns a list of settings that should change for smoothpose
         """
 
-        recommended_settings = {'imu_raw_output': Setting('imu_raw_output', 'imu', 'True'),
-                                'gyro_range': Setting('gyro_range', 'imu', '125'),
+        recommended_settings = {'gyro_range': Setting('gyro_range', 'imu', '125'),
                                 'acc_range': Setting('acc_range', 'imu', '8g'),
                                 'imu_rate': Setting('imu_rate', 'imu', '100')
                                 }

--- a/piksi_tools/console/update_view.py
+++ b/piksi_tools/console/update_view.py
@@ -360,25 +360,6 @@ class UpdateView(HasTraits):
         Handle update_stm_firmware button. Starts thread so as not to block the GUI
         thread.
         """
-        ins_settings = self.settings.get('ins', None)
-        ins_output_mode = None
-        if ins_settings is not None:
-            ins_output_mode = ins_settings.get('output_mode').value
-
-        if (ins_output_mode is not None) and not (ins_output_mode.startswith('Disabled') or ins_output_mode.startswith('disabled')):
-            ins_disable_prompt = \
-                prompt.CallbackPrompt(
-                    title="Unsupported Update Request",
-                    actions=[prompt.close_button],
-                )
-            ins_disable_prompt.text = \
-                "\n\n" + \
-                "Updating firmware is not supported when INS is active.\n\n" + \
-                "Please change the 'output mode' INS setting to 'Disabled'\n" + \
-                "before updating firmware.\n\n"
-            ins_disable_prompt.run(block=False)
-            return
-
         if self.connection_info['mode'] != 'TCP/IP':
             self._write(
                 "\n"


### PR DESCRIPTION
Design
=
As of https://github.com/swift-nav/piksi_buildroot/pull/1208 there should be significantly lower impact on device performance when fileio is transferring upgrade images. Therefore we will remove the blocking check that was instated to fix this issue in the v2.2 release cycle.

Also removed specific check for `imu_raw_output` as this is now handled automatically per swift-nav/piksi_buildroot/pull/1202 and swift-nav/piksi_firmware_private#2754

Testing
=
 - [x] Make sure you can initiate an upgrade with ins enabled
 - [x] Check for erroneous behavior during file transfer
 - [x] imu enabled set to False doesn't trigger recommended settings pop up