### PR TITLE
Add console downloader functionality to console

### DIFF
--- a/piksi_tools/console/update_downloader.py
+++ b/piksi_tools/console/update_downloader.py
@@ -61,15 +61,29 @@ class UpdateDownloader:
                 "Error downloading firmware: URL not present in index")
         return filepath
 
-    def _download_file_from_url(self, url):
+    def download_console(self, hwrev, path=None):
+        import sys
+        platform = sys.platform
+        url = self.index[hwrev]['console'][platform+'_url']
+        return self._download_file_from_url(url, path)
+
+    def _download_file_from_url(self, url, path=None):
         if not os.path.exists(self.root_dir):
             raise RuntimeError("Path to download file {0} to does not exist.".format(self.root_dir))
             return
         filename = os.path.split(urlparse(url).path)[1]
-        filename = os.path.join(self.root_dir, filename)
+        if path is None:
+            path = self.root_dir
+        filename = os.path.join(path, filename)
         requests_response = requests.get(url)
         requests_response.raise_for_status()
         blob = requests_response.content
         with sopen(filename, 'wb') as f:
             f.write(blob)
         return os.path.abspath(filename)
+
+
+def test():
+    a = UpdateDownloader()
+    a.download_multi_firmware('piksi_multi')
+    a.download_console('piksi_multi')


### PR DESCRIPTION
This pull requests adds the following features to the console.  Both features represent more or less completed development that I wanted to tidy up for possible merging.

- If the console is outdated, it prompts the user to download with the following popup.
![image](https://user-images.githubusercontent.com/11276774/58057989-08e46f80-7b1c-11e9-8ec7-8cac81e3d3c4.png)

- It adds a new "Download Latest Console" button on update view
![image](https://user-images.githubusercontent.com/11276774/58058060-434e0c80-7b1c-11e9-9089-df8246dab45c.png)

If user presses ok in the first popup or the new button, a file chooser dialog opens up to choose a location to download.  Then the console installer for the platform is downloaded.  During download, periods print across the screen to indicate that something is happened a status message appears in Firmware upgrades status window per below when finished.

![image](https://user-images.githubusercontent.com/11276774/58058121-7db7a980-7b1c-11e9-956b-be7d678990e7.png)
