### PR TITLE
Try using UpdateScheduler for the settings view [ESD-1343]

### DIFF
--- a/piksi_tools/console/settings_view.py
+++ b/piksi_tools/console/settings_view.py
@@ -37,7 +37,7 @@ from pyface.api import FileDialog, OK
 
 from .settings_list import SettingsList
 from .utils import resource_filename
-from .gui_utils import PiksiBooleanEditor
+from .gui_utils import PiksiBooleanEditor, UpdateScheduler
 
 SETTINGS_REVERT_TIMEOUT = 5
 SETTINGS_RETRY_TIMEOUT = 10
@@ -724,7 +724,7 @@ class SettingsView(HasTraits):
             self.retry_pending_read_index_thread.stop()
         # we should only setup the display once per iteration to avoid races
         if self.setup_pending:
-            self.settings_display_setup()
+            self.update_scheduler.schedule_update('settings_read_by_index_done_callback', self.settings_display_setup)
             self.setup_pending = False
 
     def settings_read_resp_callback(self, sbp_msg, **metadata):
@@ -911,3 +911,4 @@ class SettingsView(HasTraits):
                 )
                 print("Verify that write permissions exist on the port.")
         self.python_console_cmds = {'settings': self}
+        self.update_scheduler = UpdateScheduler()


### PR DESCRIPTION
A shot in the dark, no idea if this will resolve the issue but @jaredw42's crash report from Mac shows that we're somewhere in the process of editing a table.  So if this is related to threading, then the settings view is one of the few remaining spots where we aren't using UpdateScheduler, which will constrain settings value updates to a single thread, and force them to happen on the GUI thread.  Traits are technically supposed to be thread safe, but it's possible there's a bug in the Qt5 back-end that's causing this issue.