### PR TITLE
Fix progress cb for bootload_v3

### DIFF
--- a/piksi_tools/bootload_v3.py
+++ b/piksi_tools/bootload_v3.py
@@ -81,7 +81,7 @@ def main():
     with Handler(Framer(driver.read, driver.write, verbose=args.verbose)) as link:
         data = bytearray(open(args.file, 'rb').read())
 
-        def progress_cb(size):
+        def progress_cb(size, _):
             sys.stdout.write("\rProgress: %d%%    \r" %
                              (100 * size / len(data)))
             sys.stdout.flush()


### PR DESCRIPTION
Fix this error, yay for Python:

```
c:\bin>@bootload_v3 -t -p 10.1.23.200:55555 C:\bin\PiksiMulti-v2.3.17.bin
('10.1.23.200', 55555)
Transferring image file...
Traceback (most recent call last):
  File "piksi_tools\bootload_v3.py", line 105, in <module>
  File "piksi_tools\bootload_v3.py", line 91, in main
  File "piksi_tools\fileio.py", line 565, in write
TypeError: progress_cb() takes 1 positional argument but 2 were given
[15148] Failed to execute script bootload_v3
```