### PR TITLE
fix bootload_v3 for serial port

### DIFF
--- a/piksi_tools/bootload_v3.py
+++ b/piksi_tools/bootload_v3.py
@@ -41,7 +41,7 @@ def get_args():
     """
     parser = serial_link.base_cl_options()
     parser.description = 'Piksi Bootloader'
-    parser.add_argument("file", help="the image set file to write to flash.")
+    parser.add_argument("firmware", help="the image set file to write to flash.")
     return parser.parse_args()
 
 
@@ -79,7 +79,7 @@ def main():
     # Driver with context
     # Handler with context
     with Handler(Framer(driver.read, driver.write, verbose=args.verbose)) as link:
-        data = bytearray(open(args.file, 'rb').read())
+        data = bytearray(open(args.firmware, 'rb').read())
 
         def progress_cb(size, _):
             sys.stdout.write("\rProgress: %d%%    \r" %


### PR DESCRIPTION
This is to fix the following issue with bootload_v3 observed due to argument naming conflict between what the "file" argument means in serial_link.py and bootload_v3.py
`python -m piksi_tools.bootload_v3 -p /dev/cu.usbserial-A105YHGQ  ~/Downloads/PiksiMulti-v2.3.17.bin
Transferring image file...
<sbp.client.framer.Framer object at 0x1189e4d50>
Traceback (most recent call last):
 File “/usr/local/Cellar/python@2/2.7.15_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py”, line 174, in _run_module_as_main
   “__main__“, fname, loader, pkg_name)
 File “/usr/local/Cellar/python@2/2.7.15_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py”, line 72, in _run_code
   exec code in run_globals
 File “/Users/dzollo/source/piksi_tools/piksi_tools/bootload_v3.py”, line 106, in <module>
   main()
 File “/Users/dzollo/source/piksi_tools/piksi_tools/bootload_v3.py”, line 92, in main
   b”upgrade.image_set.bin”, data, progress_cb=progress_cb)
 File “piksi_tools/fileio.py”, line 518, in write
   self.remove(filename)
 File “piksi_tools/fileio.py”, line 487, in remove
   self.link(msg)
 File “/Users/dzollo/source/piksi_tools/venv/lib/python2.7/site-packages/sbp/client/handler.py”, line 282, in __call__
   self._source(*msgs, **metadata)
 File “/Users/dzollo/source/piksi_tools/venv/lib/python2.7/site-packages/sbp/client/framer.py”, line 172, in __call__
   self._write(memoryview(self._buffer)[:index])
 File “/Users/dzollo/source/piksi_tools/venv/lib/python2.7/site-packages/sbp/client/drivers/base_driver.py”, line 56, in write
   return self.handle.write(s)
IOError: File not open for writing`