### PR TITLE
Status bar ins [STAR-833]

### DIFF
--- a/piksi_tools/console/console.py
+++ b/piksi_tools/console/console.py
@@ -56,8 +56,8 @@ from piksi_tools.console.tracking_view import TrackingView
 from piksi_tools.console.update_view import UpdateView
 from piksi_tools.console.utils import (EMPTY_STR, call_repeatedly,
                                        mode_dict, ins_mode_dict, ins_type_dict,
-                                       resource_filename, icon, swift_path, 
-                                       DR_MODE, DIFFERENTIAL_MODES)
+                                       ins_error_dict, resource_filename, icon,
+                                       swift_path, DR_MODE, DIFFERENTIAL_MODES)
 
 
 class ArgumentParserError(Exception):
@@ -487,10 +487,14 @@ class SwiftConsole(HasTraits):
             ins_mode = ins_flags & 0x7
             ins_type = (ins_flags >> 29) & 0x7
             odo_status = (ins_flags >> 8) & 0x3
-            ins_status_string = ins_type_dict.get(ins_type, "unk") + "-"
-            ins_status_string += ins_mode_dict.get(ins_mode, "unk")
-            if odo_status == 1:
-                ins_status_string += "+Odo"
+            ins_error = (ins_flags >> 4) & 0xF
+            if ins_error != 0:
+                ins_status_string = ins_error_dict.get(ins_error, "Unk Error")
+            else:
+                ins_status_string = ins_type_dict.get(ins_type, "unk") + "-"
+                ins_status_string += ins_mode_dict.get(ins_mode, "unk")
+                if odo_status == 1:
+                    ins_status_string += "+Odo"
             self.ins_status_string = ins_status_string
 
         # select the solution mode displayed in the status bar:

--- a/piksi_tools/console/console.py
+++ b/piksi_tools/console/console.py
@@ -18,6 +18,7 @@ import os
 import signal
 import sys
 import time
+from monotonic import monotonic
 # Shut chaco up for now
 import warnings
 
@@ -54,8 +55,9 @@ from piksi_tools.console.system_monitor_view import SystemMonitorView
 from piksi_tools.console.tracking_view import TrackingView
 from piksi_tools.console.update_view import UpdateView
 from piksi_tools.console.utils import (EMPTY_STR, call_repeatedly,
-                                       mode_dict, resource_filename,
-                                       icon, swift_path, DR_MODE, DIFFERENTIAL_MODES)
+                                       mode_dict, ins_mode_dict, ins_type_dict,
+                                       resource_filename, icon, swift_path, 
+                                       DR_MODE, DIFFERENTIAL_MODES)
 
 
 class ArgumentParserError(Exception):
@@ -170,7 +172,8 @@ class SwiftConsole(HasTraits):
   """
 
     mode = Str('')
-    num_sats = Int(0)
+    ins_status_string = Str('')
+    num_sats_str = Str('')
     cnx_desc = Str('')
     age_of_corrections = Str('')
     uuid = Str('')
@@ -327,7 +330,7 @@ class SwiftConsole(HasTraits):
                         emphasized=True,
                         tooltip='Number of satellites used in solution'),
                     Item(
-                        'num_sats',
+                        'num_sats_str',
                         padding=2,
                         show_label=False,
                         style='readonly'),
@@ -344,11 +347,11 @@ class SwiftConsole(HasTraits):
                         style='readonly'),
                     Item(
                         '',
-                        label='Device UUID:',
+                        label='INS Status:',
                         emphasized=True,
-                        tooltip='Universally Unique Device Identifier (UUID)'
+                        tooltip='INS Status String'
                     ), Item(
-                        'uuid',
+                        'ins_status_string',
                         padding=2,
                         show_label=False,
                         style='readonly', width=6),
@@ -440,6 +443,9 @@ class SwiftConsole(HasTraits):
         # if our heartbeat hasn't changed since the last timer interval the connection must have dropped
         if self.heartbeat_count == self.last_timer_heartbeat:
             self.solid_connection = False
+            self.ins_status_string = "None"
+            self.mode = "None"
+            self.num_sats_str = EMPTY_STR
         else:
             self.solid_connection = True
         self.last_timer_heartbeat = self.heartbeat_count
@@ -474,15 +480,28 @@ class SwiftConsole(HasTraits):
                 baseline_num_sats = self.baseline_view.last_soln.n_sats
             baseline_is_differential = (baseline_solution_mode in DIFFERENTIAL_MODES)
 
+        # determine the latest INS mode
+        if self.solution_view and (monotonic() -
+                                   self.solution_view.last_ins_status_receipt_time) < 1:
+            ins_flags = self.solution_view.ins_status_flags
+            ins_mode = ins_flags & 0x7
+            ins_type = (ins_flags >> 29) & 0x7
+            odo_status = (ins_flags >> 8) & 0x3
+            ins_status_string = ins_type_dict.get(ins_type, "unk") + "-"
+            ins_status_string += ins_mode_dict.get(ins_mode, "unk")
+            if odo_status == 1:
+                ins_status_string += "+Odo"
+            self.ins_status_string = ins_status_string
+
         # select the solution mode displayed in the status bar:
         # * baseline if it's a differential solution but llh isn't
         # * otherwise llh (also if there is no solution, in which both are "None")
         if baseline_is_differential and not(llh_is_differential):
             self.mode = baseline_display_mode
-            self.num_sats = baseline_num_sats
+            self.num_sats_str = "{}".format(baseline_num_sats)
         else:
             self.mode = llh_display_mode
-            self.num_sats = llh_num_sats
+            self.num_sats_str = "{}".format(llh_num_sats)
 
         # --- end of status bar mode determination section ---
 
@@ -590,8 +609,9 @@ class SwiftConsole(HasTraits):
         self.cnx_desc = cnx_desc
         self.connection_info = connection_info
         self.dev_id = cnx_desc
-        self.num_sats = 0
+        self.num_sats_str = EMPTY_STR
         self.mode = ''
+        self.ins_status_string = "None"
         self.forwarder = None
         self.age_of_corrections = '--'
         self.expand_json = expand_json

--- a/piksi_tools/console/solution_view.py
+++ b/piksi_tools/console/solution_view.py
@@ -545,7 +545,7 @@ class SolutionView(HasTraits):
 
         self.dops_table.append(('DOPS Flags', '0x%03x' % flags))
         self.dops_table.append(('INS Status', '0x{:0}'.format(self.ins_status_flags)))
-    
+
     def ins_status_callback(self, sbp_msg, **metadata):
         status = MsgInsStatus(sbp_msg)
         self.ins_status_flags = status.flags

--- a/piksi_tools/console/solution_view.py
+++ b/piksi_tools/console/solution_view.py
@@ -549,6 +549,7 @@ class SolutionView(HasTraits):
     def ins_status_callback(self, sbp_msg, **metadata):
         status = MsgInsStatus(sbp_msg)
         self.ins_status_flags = status.flags
+        self.last_ins_status_receipt_time = monotonic()
 
     def vel_ned_callback(self, sbp_msg, **metadata):
         flags = 0
@@ -673,6 +674,7 @@ class SolutionView(HasTraits):
         self.directory_name_p = dirname
         self.vel_log_file = None
         self.last_stime_update = 0
+        self.last_ins_status_receipt_time = 0
         self.last_soln = None
 
         self.altitude = 0

--- a/piksi_tools/console/utils.py
+++ b/piksi_tools/console/utils.py
@@ -451,6 +451,27 @@ mode_dict = {
     SBAS_MODE: 'SBAS'
 }
 
+
+AWAITING_INITIALIZATION = 0
+DYNAMICALLY_ALIGNING = 1
+READY = 2
+GNSS_OUTAGE_MAX = 3
+
+ins_mode_dict = {
+    AWAITING_INITIALIZATION: "Init",
+    DYNAMICALLY_ALIGNING: "Align",
+    READY: "Ready",
+    GNSS_OUTAGE_MAX: "MaxDur"
+}
+
+SMOOTHPOSE = 0
+DR_RUNNER = 1
+
+ins_type_dict = {
+    SMOOTHPOSE: "SP",
+    DR_RUNNER: "DR"
+    }
+
 color_dict = {
     NO_FIX_MODE: None,
     SPP_MODE: (0, 0, 1.0),

--- a/piksi_tools/console/utils.py
+++ b/piksi_tools/console/utils.py
@@ -464,6 +464,16 @@ ins_mode_dict = {
     GNSS_OUTAGE_MAX: "MaxDur"
 }
 
+IMU_DATA_ERROR = 1
+IMU_LICENSE_ERROR = 2
+IMU_CALIBRATION_ERROR = 3
+
+ins_error_dict = {
+        IMU_DATA_ERROR: "Data Error",
+        IMU_LICENSE_ERROR: "License Error",
+        IMU_CALIBRATION_ERROR: "Cal Error"
+        }
+
 SMOOTHPOSE = 0
 DR_RUNNER = 1
 

--- a/piksi_tools/console/utils.py
+++ b/piksi_tools/console/utils.py
@@ -469,10 +469,10 @@ IMU_LICENSE_ERROR = 2
 IMU_CALIBRATION_ERROR = 3
 
 ins_error_dict = {
-        IMU_DATA_ERROR: "Data Error",
-        IMU_LICENSE_ERROR: "License Error",
-        IMU_CALIBRATION_ERROR: "Cal Error"
-        }
+    IMU_DATA_ERROR: "Data Error",
+    IMU_LICENSE_ERROR: "License Error",
+    IMU_CALIBRATION_ERROR: "Cal Error"
+}
 
 SMOOTHPOSE = 0
 DR_RUNNER = 1
@@ -480,7 +480,7 @@ DR_RUNNER = 1
 ins_type_dict = {
     SMOOTHPOSE: "SP",
     DR_RUNNER: "DR"
-    }
+}
 
 color_dict = {
     NO_FIX_MODE: None,


### PR DESCRIPTION
This adds some user friendly strings to the INS status bar based upon the latest definition of MSG_INS_STATUS.  It also fixes up the fact that a missing solution message showed the last valid mode and the last valid number of sats without a timeout.   This should prevent any head scratching if license file is missing, or raw IMU isn't turned on.  This must correspond with whitelisting MSG_INS_STATUS in buildroot for all ports by default.

I could be convinced to shorten the header from "INS STATUS" to "INS".

Looks like this:
![image](https://user-images.githubusercontent.com/11276774/66245314-e2d1fd00-e6c1-11e9-80bf-7622f54e56b2.png)


Refer to SBP Spec.
![image](https://user-images.githubusercontent.com/11276774/66245277-abfbe700-e6c1-11e9-9891-14c127bb6e40.png)

As for testing, I've tested on my desk over etherent against a piksi multi inertial.

/cc @jaredw42 @swiftnav-ram @scarcanague @kmdade 