### PR TITLE
add data rate display to console and serial_link

### DIFF
--- a/piksi_tools/console/utils.py
+++ b/piksi_tools/console/utils.py
@@ -3,12 +3,10 @@ from __future__ import print_function
 
 import datetime
 import pkg_resources
-import time
 import os
 import locale
 
 from functools import partial
-from threading import Event, Thread
 
 from pyface.image_resource import ImageResource
 from sbp.navigation import (SBP_MSG_BASELINE_NED, SBP_MSG_BASELINE_NED_DEP_A,
@@ -652,19 +650,6 @@ def log_time_strings(week, tow):
     t = datetime.datetime.now()
     (t_local_date, t_local_secs) = datetime_2_str(t)
     return ((t_local_date, t_local_secs), (t_gps_date, t_gps_secs))
-
-
-def call_repeatedly(interval, func, *args):
-    stopped = Event()
-
-    def loop():
-        # https://stackoverflow.com/questions/29082268/python-time-sleep-vs-event-wait
-        while not stopped.is_set():
-            func(*args)
-            time.sleep(interval)
-
-    Thread(target=loop).start()
-    return stopped.set
 
 
 def get_label(key, extra={}):

--- a/piksi_tools/serial_link.py
+++ b/piksi_tools/serial_link.py
@@ -30,7 +30,7 @@ from sbp.client.loggers.null_logger import NullLogger
 from sbp.logging import SBP_MSG_LOG, SBP_MSG_PRINT_DEP, MsgLog
 from sbp.piksi import MsgReset
 
-from piksi_tools.utils import mkdir_p, get_tcp_driver
+from piksi_tools.utils import mkdir_p, get_tcp_driver, call_repeatedly
 from piksi_tools import __version__ as VERSION
 
 SERIAL_PORT = "/dev/ttyUSB0"
@@ -153,6 +153,11 @@ def get_args():
         "--timeout",
         default=None,
         help="exit after TIMEOUT seconds have elapsed.")
+    parser.add_argument(
+        "--status",
+        default=False,
+        action="store_true",
+        help="print periodic data rate to stdout.")
     return parser.parse_args()
 
 
@@ -353,7 +358,7 @@ def main(args):
     if log_dirname:
         log_filename = os.path.join(log_dirname, log_filename)
     driver = get_base_args_driver(args)
-    sender_id_filter_list = []
+    sender_id_filter = []
     if args.sender_id_filter is not None:
         sender_id_filter = [int(x) for x in args.sender_id_filter.split(",")]
     if args.json:
@@ -364,7 +369,13 @@ def main(args):
                         args.verbose,
                         skip_metadata=args.skip_metadata,
                         sender_id_filter_list=sender_id_filter)
-
+    last_bytes_read = [0]
+    if args.status:
+        def print_io_data(last_bytes_read):
+            print("{0:.2f} KB/s average data rate (2 second period).".format((driver.total_bytes_read -
+                                                                              last_bytes_read[0])/(2 * 1024.0)))
+            last_bytes_read[0] = driver.total_bytes_read
+        call_repeatedly(2, print_io_data, last_bytes_read)
     with Handler(source, autostart=False) as link, get_logger(args.log,
                                                               log_filename,
                                                               args.expand_json,

--- a/piksi_tools/serial_link.py
+++ b/piksi_tools/serial_link.py
@@ -381,8 +381,9 @@ def main(args):
     last_bytes_read = [0]
     if args.status:
         def print_io_data(last_bytes_read):
-            print("{0:.2f} KB/s average data rate (2 second period).".format((driver.total_bytes_read -
-                                                                              last_bytes_read[0])/(2 * 1024.0)))
+            # bitrate is will be kilobytes per second. 2 second period, 1024 bytes per kilobyte
+            print(
+                "{0:.2f} KB/s average data rate (2 second period).".format((driver.bytes_read_since(last_bytes_read[0]))/(2 * 1024.0)))
             last_bytes_read[0] = driver.total_bytes_read
         stop_function = call_repeatedly(2, print_io_data, last_bytes_read)
     with Handler(source, autostart=False) as link, get_logger(args.log,

--- a/piksi_tools/utils.py
+++ b/piksi_tools/utils.py
@@ -16,6 +16,9 @@ import monotonic
 import os
 import socket
 import sys
+import time
+
+from threading import Event, Thread
 
 from sbp.client.drivers.network_drivers import TCPDriver
 
@@ -62,6 +65,19 @@ def get_tcp_driver(host, port=None):
         raise Exception('TCP connection timed out. Check host: {}'.format(host))
     except Exception as e:
         raise Exception('Invalid host and/or port: {}'.format(str(e)))
+
+
+def call_repeatedly(interval, func, *args):
+    stopped = Event()
+
+    def loop():
+        # https://stackoverflow.com/questions/29082268/python-time-sleep-vs-event-wait
+        while not stopped.is_set():
+            func(*args)
+            time.sleep(interval)
+
+    Thread(target=loop).start()
+    return stopped.set
 
 
 class Time(object):


### PR DESCRIPTION
Adds data rate display to swift console in Kilobytes per second:
 
requires https://github.com/swift-nav/libsbp/pull/775

Looks like this if disconnected completely:
![image](https://user-images.githubusercontent.com/11276774/74192336-332a1000-4c0a-11ea-83f0-5c35c176d6dd.png)
This is connected to something but there is no SBP_MSG_HEARTBEAT
![image](https://user-images.githubusercontent.com/11276774/74192388-4d63ee00-4c0a-11ea-85b3-5bb271fd9ce6.png)

and this if connected and has heartbeat:
![image](https://user-images.githubusercontent.com/11276774/74192420-5eacfa80-4c0a-11ea-8e26-5c32f6d495dc.png)

Averaging period is 1.2 seconds to avoid ping-ponging on either side of 1Hz GNSS epochs and misleading people.

