### PR TITLE
Playback support in serial_link (#1138)

### DIFF
--- a/piksi_tools/console/console.py
+++ b/piksi_tools/console/console.py
@@ -24,6 +24,7 @@ from monotonic import monotonic
 import warnings
 
 import sbp.client as sbpc
+from sbp.client.loggers.json_logger import JSONLogIterator
 from enable.savage.trait_defs.ui.svg_button import SVGButton
 from pyface.image_resource import ImageResource
 from sbp.ext_events import SBP_MSG_EXT_EVENT, MsgExtEvent
@@ -928,28 +929,31 @@ def main():
         print('Unable to Initialize Connection. Exiting...')
         sys.exit(1)
 
-    with cnx_data.driver as driver:
-        with sbpc.Handler(
-                sbpc.Framer(driver.read, driver.write, args.verbose)) as link:
-            if args.reset:
-                link(MsgReset(flags=0))
-            log_filter = DEFAULT_LOG_LEVEL_FILTER
-            if args.initloglevel[0]:
-                log_filter = args.initloglevel[0]
-            with SwiftConsole(
-                    link,
-                    args.update,
-                    log_filter,
-                    cnx_desc=cnx_data.description,
-                    error=args.error,
-                    json_logging=args.log,
-                    log_dirname=args.log_dirname,
-                    override_filename=args.logfilename,
-                    log_console=args.log_console,
-                    connection_info=cnx_data.connection_info,
-                    expand_json=args.expand_json) as console:
+    if args.json:
+        source = JSONLogIterator(cnx_data.driver, conventional=True)
+    else:
+        source = sbpc.Framer(cnx_data.driver.read, cnx_data.driver.write, args.verbose)
 
-                console.configure_traits()
+    with sbpc.Handler(source) as link:
+        if args.reset:
+            link(MsgReset(flags=0))
+        log_filter = DEFAULT_LOG_LEVEL_FILTER
+        if args.initloglevel[0]:
+            log_filter = args.initloglevel[0]
+        with SwiftConsole(
+                link,
+                args.update,
+                log_filter,
+                cnx_desc=cnx_data.description,
+                error=args.error,
+                json_logging=args.log,
+                log_dirname=args.log_dirname,
+                override_filename=args.logfilename,
+                log_console=args.log_console,
+                connection_info=cnx_data.connection_info,
+                expand_json=args.expand_json) as console:
+
+            console.configure_traits()
 
     # TODO: solve this properly
     # Force exit, even if threads haven't joined

--- a/piksi_tools/sbpjson_expand.py
+++ b/piksi_tools/sbpjson_expand.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+# Copyright (C) 2020 Swift Navigation Inc.
+# Contact: Swift Navigation <dev@swiftnav.com>
+#
+# This source is subject to the license found in the file 'LICENSE' which must
+# be be distributed together with this source. All other rights reserved.
+#
+# THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+
+import argparse
+import os
+
+from sbp.client.loggers.json_logger import JSONLogger, JSONLogIterator
+
+
+def get_args():
+    """
+    Get and parse arguments.
+    """
+    parser = argparse.ArgumentParser(description='SBP JSON payload expander')
+
+    parser.add_argument(
+        'filename',
+        help="The SBP log file to extract data from. Default format is sbp json")
+
+    parser.add_argument(
+        '-i',
+        '--ignore',
+        default=[],
+        type=int,
+        nargs='*',
+        help="Filter message types")
+
+    args = parser.parse_args()
+
+    return args
+
+
+def main():
+    args = get_args()
+    logger = JSONLogger(None)
+
+    name, ext = os.path.splitext(args.filename)
+
+    outfile = "{name}-expanded{ext}".format(name=name, ext=ext)
+
+    with open(args.filename, 'r') as infile, open(outfile, 'w') as outfile:
+        for (msg, meta) in JSONLogIterator(infile, conventional=True):
+
+            if msg.msg_type in args.ignore:
+                continue
+
+            outfile.write(logger.dump(msg))
+            outfile.write('\n')
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ pygments==2.2.0
 requests~=2.20.0
 six==1.13.0
 libsettings==0.1.12
-sbp==2.7.6
+sbp==2.7.7
 ruamel.yaml==0.15.87
 setuptools==41.0.1
 setuptools_scm==3.1.0


### PR DESCRIPTION
* Add JSON log iterator as possible source

* Script for expanding SBP JSON payloads

* Use common JSONLogIterator

* sbpjson_expand.py: Use conventional JSONLogIterator

* Update sbp requirement to 2.7.7 to include playback feature

* Add playback option to serial_link

Co-authored-by: Jason Mobarak <jason@swift-nav.com>