### PR TITLE
[PMF-95] Prevent write-back

### DIFF
--- a/piksi_tools/console/settings_view.py
+++ b/piksi_tools/console/settings_view.py
@@ -178,7 +178,7 @@ class Setting(SettingBase):
         if self.readonly:
             return
 
-        self.update_value(value, False)
+        self.update_value(old, False)
 
         invalid_setting_prompt = prompt.CallbackPrompt(
             title="Settings Write Error: {}.{}".format(section, name),

--- a/piksi_tools/console/settings_view.py
+++ b/piksi_tools/console/settings_view.py
@@ -178,7 +178,7 @@ class Setting(SettingBase):
         if self.readonly:
             return
 
-        self.update_value(old, False)
+        self.update_value_skip_write_req(old)
 
         invalid_setting_prompt = prompt.CallbackPrompt(
             title="Settings Write Error: {}.{}".format(section, name),
@@ -258,8 +258,8 @@ class Setting(SettingBase):
 
         self.settings.workqueue.put(self._write_value, old, new)
 
-    def update_value(self, new, send_write_req):
-        self.skip_write_req = not send_write_req
+    def update_value_skip_write_req(self, new):
+        self.skip_write_req = True
         self.value = new
         self.skip_write_req = False
 
@@ -588,7 +588,7 @@ class SettingsView(HasTraits):
             # setting exists, we won't reinitilize it but rather update existing setting
             existing_setting = self.settings[section].get(name, False)
             if existing_setting:
-                existing_setting.update_value(value, False)
+                existing_setting.update_value_skip_write_req(value)
                 existing_setting.ordering = idx
                 if setting_type == 'enum':
                     enum_values = setting_format.split(',')
@@ -729,7 +729,7 @@ class SettingsView(HasTraits):
                 self._import_failure_write(error, section, name)
                 success = False
             else:
-                self.settings.get(section, None).get(name, None).update_value(value, False)
+                self.settings.get(section, None).get(name, None).update_value_skip_write_req(value)
 
         if success:
             self._import_success(len(ret))


### PR DESCRIPTION
https://swift-nav.atlassian.net/browse/PMF-95

Bug description:
1. Run console and Piksi with `pfwp_build_date` `a.b.c`
2. Make sure console has executed `_read_all_thread`
3. Update Piksi build with  `pfwp_build_date` `x.y.z` and reboot Piksi and do not restart console
4. Piksi reboots, console detects it and executes `_read_all_thread`
5. New `pfwp_build_date` value is assigned in the console
6. Since `pfwp_build_date` value has changed, console sends `MSG_SETTINGS_WRITE`
7. Firmware settings client receives the write request and detects that it tries to update read-only setting
8. Warning is issued and request rejected

This PR omits steps 6-8.