### PR TITLE
Do not use baseline view last_mode unless in DGNSS mode

### DIFF
--- a/piksi_tools/console/console.py
+++ b/piksi_tools/console/console.py
@@ -479,7 +479,7 @@ class SwiftConsole(HasTraits):
                 llh_display_mode += "+INS"
 
         # determine the latest baseline solution mode
-        if self.baseline_view:
+        if self.baseline_view and self.settings_view and self.settings_view.dgnss_enabled():
             baseline_solution_mode = self.baseline_view.last_mode
             baseline_display_mode = mode_dict.get(baseline_solution_mode, EMPTY_STR)
             if baseline_solution_mode > 0 and self.baseline_view.last_soln:

--- a/piksi_tools/console/settings_view.py
+++ b/piksi_tools/console/settings_view.py
@@ -825,6 +825,12 @@ class SettingsView(HasTraits):
         """ Remove callbacks from serial link. """
         self.link.remove_callback(self.piksi_startup_callback, SBP_MSG_STARTUP)
 
+    def dgnss_enabled(self):
+        try:
+            return self.settings["solution"]["dgnss_solution_mode"].value != "No DGNSS"
+        except KeyError:
+            return False
+
     def __enter__(self):
         return self
 


### PR DESCRIPTION
Mitigate status bar fix type field defect found in https://swift-nav.atlassian.net/browse/PMF-36

Note that this doesn't change the baseline view aspect, it's still showing the last received data.

Not super pleased with this change but I think this is one of the least intrusive hackerinos to mitigate the status bar bug. Probably would be a good idea to separate the fix types between solution and baseline if they can differ since it's hard/impossible to do a logical implementation if two concepts are forced into one space.