### PR TITLE
Merge cherry-picks from refs/heads/v2.4.0-release (47004ac68) into master: Do not use baseline view last_mode unless in DGNSS mode (#1155)

### DIFF
--- a/piksi_tools/console/console.py
+++ b/piksi_tools/console/console.py
@@ -477,7 +477,7 @@ class SwiftConsole(HasTraits):
                 llh_display_mode += "+INS"
 
         # determine the latest baseline solution mode
-        if self.baseline_view:
+        if self.baseline_view and self.settings_view and self.settings_view.dgnss_enabled():
             baseline_solution_mode = self.baseline_view.last_mode
             baseline_display_mode = mode_dict.get(baseline_solution_mode, EMPTY_STR)
             if baseline_solution_mode > 0 and self.baseline_view.last_soln:

--- a/piksi_tools/console/settings_view.py
+++ b/piksi_tools/console/settings_view.py
@@ -825,6 +825,12 @@ class SettingsView(HasTraits):
         """ Remove callbacks from serial link. """
         self.link.remove_callback(self.piksi_startup_callback, SBP_MSG_STARTUP)
 
+    def dgnss_enabled(self):
+        try:
+            return self.settings["solution"]["dgnss_solution_mode"].value != "No DGNSS"
+        except KeyError:
+            return False
+
     def __enter__(self):
         return self
 


### PR DESCRIPTION
Merges cherry-picked changes from release branch refs/heads/v2.4.0-release into the integration branch master