### PR TITLE
added status text for clock steering [INFRA-58]

### DIFF
--- a/piksi_tools/console/settings.yaml
+++ b/piksi_tools/console/settings.yaml
@@ -112,7 +112,7 @@
 
 - group: frontend
   name: activate_clock_steering
-  expert: false
+  expert: true
   type: bool
   units: N/A
   default value: 'False'

--- a/piksi_tools/console/settings.yaml
+++ b/piksi_tools/console/settings.yaml
@@ -110,6 +110,18 @@
     be provided on the Piksi Multi evaluation board through a labeled SMA connector. 
     It is not exposed on Duro.
 
+- group: frontend
+  name: activate_clock_steering
+  expert: false
+  type: bool
+  units: N/A
+  default value: 'False'
+  readonly: false
+  Description: Enable/Disable Clock Steering of RF frontend.
+  Notes: This setting toggles the clock steering for the RF frontend. If timing drift
+  is detected in the onboard oscillator, the clock will be continuously adjusted to align
+  more precisely with clock data encoded within the GNSS signals received by the device.
+
 - group: rtcm_out
   name: output_mode
   expert: true

--- a/piksi_tools/console/settings.yaml
+++ b/piksi_tools/console/settings.yaml
@@ -119,8 +119,8 @@
   readonly: false
   Description: Enable/Disable Clock Steering of RF frontend.
   Notes: This setting toggles the clock steering for the RF frontend. If timing drift
-  is detected in the onboard oscillator, the clock will be continuously adjusted to align
-  more precisely with clock data encoded within the GNSS signals received by the device.
+    is detected in the onboard oscillator, the clock will be continuously adjusted to align
+    more precisely with clock data encoded within the GNSS signals received by the device.
 
 - group: rtcm_out
   name: output_mode


### PR DESCRIPTION
Add documentation for the `frontend.activate_clock_steering` setting.

https://github.com/swift-nav/piksi_firmware_private/blob/d3b43e3a6265d365d4a36a59fca57e69ab3b7be9/src/board/v3/peripherals/rf_clk.c#L26