### PR TITLE
Drive tracking view from OBS message if no tracking or measurement st…

### DIFF
--- a/piksi_tools/console/console.py
+++ b/piksi_tools/console/console.py
@@ -670,7 +670,8 @@ class SwiftConsole(HasTraits):
                 self.link,
                 name='Local',
                 relay=False,
-                dirname=self.directory_name)
+                dirname=self.directory_name,
+                tracking_view=self.tracking_view)
             self.observation_view_base = ObservationView(
                 self.link,
                 name='Remote',


### PR DESCRIPTION
This PR drives the tracking tab from incoming MSG_OBS if no MSG_TRACKING_STATE or MSG_MEASUREMENT_STATE have yet been received.  Tracking tab should behave identically in either case.  This make the console compatible with systems that don't produce separate tracking information (i.e non piksi Multi receivers in use).

/cc @switanis @cbeighley @silverjam 