### PR TITLE
Dzollo/sender id filter rc 89

### DIFF
--- a/piksi_tools/console/console.py
+++ b/piksi_tools/console/console.py
@@ -930,10 +930,14 @@ def main():
         print('Unable to Initialize Connection. Exiting...')
         sys.exit(1)
 
+    sender_id_filter = []
+    if args.sender_id_filter is not None:
+        sender_id_filter = [int(x) for x in args.sender_id_filter.split(",")]
     if args.json:
         source = JSONLogIterator(cnx_data.driver, conventional=True)
     else:
-        source = sbpc.Framer(cnx_data.driver.read, cnx_data.driver.write, args.verbose)
+        source = sbpc.Framer(cnx_data.driver.read, cnx_data.driver.write,
+                             args.verbose, sender_id_filter_list=sender_id_filter)
 
     with sbpc.Handler(source) as link:
         if args.reset:

--- a/piksi_tools/serial_link.py
+++ b/piksi_tools/serial_link.py
@@ -137,6 +137,10 @@ def base_cl_options(override_arg_parse=None, add_help=True,
             "--sort-keys",
             action="store_true",
             help="Sort JSON log elements by keys.")
+        parser.add_argument(
+            "--sender-id-filter",
+            default=None,
+            help="comma separated List of base10 sender_ids: e.g: 4096,0")
     return parser
 
 
@@ -349,14 +353,17 @@ def main(args):
     if log_dirname:
         log_filename = os.path.join(log_dirname, log_filename)
     driver = get_base_args_driver(args)
-
+    sender_id_filter_list = []
+    if args.sender_id_filter is not None:
+        sender_id_filter = [int(x) for x in args.sender_id_filter.split(",")]
     if args.json:
         source = JSONLogIterator(driver, conventional=True)
     else:
         source = Framer(driver.read,
                         driver.write,
                         args.verbose,
-                        skip_metadata=args.skip_metadata)
+                        skip_metadata=args.skip_metadata,
+                        sender_id_filter_list=sender_id_filter)
 
     with Handler(source, autostart=False) as link, get_logger(args.log,
                                                               log_filename,

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ pygments==2.2.0
 requests~=2.20.0
 six==1.13.0
 libsettings==0.1.12
-sbp==2.7.7
+sbp==3.1.1
 ruamel.yaml==0.15.87
 setuptools==41.0.1
 setuptools_scm==3.1.0


### PR DESCRIPTION
Add option to filter by sender-id when initializing console or serial-link.

Requires libsbp change:
https://github.com/swift-nav/libsbp/pull/813