### PR TITLE
explicitely set JSON logfile name local time.  Windows users reported…

### DIFF
--- a/piksi_tools/console/console.py
+++ b/piksi_tools/console/console.py
@@ -556,7 +556,7 @@ class SwiftConsole(HasTraits):
         if override_filename:
             filename = override_filename
         else:
-            filename = time.strftime("swift-gnss-%Y%m%d-%H%M%S.sbp.json")
+            filename = time.strftime("swift-gnss-%Y%m%d-%H%M%S.sbp.json", time.localtime())
             filename = os.path.normpath(
                 os.path.join(self.directory_name, filename))
         self.logger = s.get_logger(True, filename, self.expand_json)


### PR DESCRIPTION
… GMTIME was used for filename.