### PR TITLE
Merge cherry-picks from refs/heads/v2.4.0-release (baafd40c7) into master: explicitely set JSON logfile name local time.  Windows users reported GMTIME was used for filename.

### DIFF
--- a/piksi_tools/console/console.py
+++ b/piksi_tools/console/console.py
@@ -551,7 +551,7 @@ class SwiftConsole(HasTraits):
         if override_filename:
             filename = override_filename
         else:
-            filename = time.strftime("swift-gnss-%Y%m%d-%H%M%S.sbp.json")
+            filename = time.strftime("swift-gnss-%Y%m%d-%H%M%S.sbp.json", time.localtime())
             filename = os.path.normpath(
                 os.path.join(self.directory_name, filename))
         self.logger = s.get_logger(True, filename, self.expand_json)


### PR DESCRIPTION
Merges cherry-picked changes from release branch refs/heads/v2.4.0-release into the integration branch master