### PR TITLE
Setup CI to publish to standard locations [INFRA-290]

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,10 +11,6 @@ environment:
     - PYTHON: C:\Python35
       PYTHON_VERSION: 3.5
       PYTHON_ARCH: 32
-      AWS_ACCESS_KEY_ID:
-        secure: EuCaMnpZf+p0AsyTZfzaQFeIV9pEmdXbiMV+zpXU3yA=
-      AWS_SECRET_ACCESS_KEY:
-        secure: W+bQVzFbXdhsXH8NqLDYn9qRHCHy+1HGzk/JWwtiI04OiJP+RJPY48juk3V3l0nI
 
 cache:
   # Cache downloaded pip packages and built wheels.

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,6 +7,11 @@ environment:
     # See: http://stackoverflow.com/a/13751649/163740
     CMD_IN_ENV: 'cmd /E:ON /V:ON /C .\tasks\run_with_env.cmd'
 
+    AWS_ACCESS_KEY_ID:
+      secure: EuCaMnpZf+p0AsyTZfzaQFeIV9pEmdXbiMV+zpXU3yA=
+    AWS_SECRET_ACCESS_KEY:
+      secure: W+bQVzFbXdhsXH8NqLDYn9qRHCHy+1HGzk/JWwtiI04OiJP+RJPY48juk3V3l0nI
+
   matrix:
     - PYTHON: C:\Python35
       PYTHON_VERSION: 3.5
@@ -29,7 +34,7 @@ install:
   - SET PYTHONPATH=.
   - python --version
   # Upgrade to the latest pip.
-  - '%CMD_IN_ENV% python -m pip install -U pip setuptools wheel tox'
+  - '%CMD_IN_ENV% python -m pip install -U pip setuptools wheel tox awscli'
   - powershell .\\tasks\\missing-headers.ps1
   - '%CMD_IN_ENV% python scripts\build_release.py'
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,16 +7,14 @@ environment:
     # See: http://stackoverflow.com/a/13751649/163740
     CMD_IN_ENV: 'cmd /E:ON /V:ON /C .\tasks\run_with_env.cmd'
 
-    AWS_ACCESS_KEY_ID:
-      secure: EuCaMnpZf+p0AsyTZfzaQFeIV9pEmdXbiMV+zpXU3yA=
-    AWS_SECRET_ACCESS_KEY:
-      secure: W+bQVzFbXdhsXH8NqLDYn9qRHCHy+1HGzk/JWwtiI04OiJP+RJPY48juk3V3l0nI
-
   matrix:
     - PYTHON: C:\Python35
       PYTHON_VERSION: 3.5
       PYTHON_ARCH: 32
-
+      AWS_ACCESS_KEY_ID:
+        secure: EuCaMnpZf+p0AsyTZfzaQFeIV9pEmdXbiMV+zpXU3yA=
+      AWS_SECRET_ACCESS_KEY:
+        secure: W+bQVzFbXdhsXH8NqLDYn9qRHCHy+1HGzk/JWwtiI04OiJP+RJPY48juk3V3l0nI
 
 cache:
   # Cache downloaded pip packages and built wheels.

--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,5 @@ swift_nap_*.hex
 # Conda
 .conda_py27
 .conda_py35
+
+.*.sw?

--- a/scripts/build_release.py
+++ b/scripts/build_release.py
@@ -15,13 +15,13 @@ from six.moves import reload_module
 BIONIC_DOCKER_TAG = 'swiftnav/piksi-tools-bionic:2019.06.20'
 S3_BUCKET = 'swiftnav-artifacts'
 
-appveyor_pr = os.environ.get("APPVEYOR_PULL_REQUEST_NUMBER", "")
-travis_pr = os.environ.get("TRAVIS_PULL_REQUEST", "false")
+APPVEYOR_PR = os.environ.get("APPVEYOR_PULL_REQUEST_NUMBER", "")
+TRAVIS_PR = os.environ.get("TRAVIS_PULL_REQUEST", "false")
 
-if (appveyor_pr != "" or travis_pr != "false"):
+if (APPVEYOR_PR != "" or TRAVIS_PR != "false"):
     S3_BUCKET = 'swiftnav-artifacts-pull-requests'
 
-print("S3_BUCKET: {} (APPVEYOR_PULL_REQUEST_NUMBER: {}, TRAVIS_PULL_REQUEST: {})".format(S3_BUCKET, appveyor_pr, travis_pr))
+print("S3_BUCKET: {} (APPVEYOR_PULL_REQUEST_NUMBER: {}, TRAVIS_PULL_REQUEST: {})".format(S3_BUCKET, APPVEYOR_PR, TRAVIS_PR))
 
 
 def maybe_remove(path):
@@ -171,6 +171,10 @@ def build_win():
         '-XOutfile ../{}'.format(installer_path),
         'misc/swift_console.nsi'
     ])
+
+    if APPVEYOR_PR:
+        print("skipping upload to AWS for AppVeyor PR (secure variable are not decrypted in PRs: https://www.appveyor.com/docs/how-to/secure-files)")
+        return
 
     check_call(['where', 'aws'])
 

--- a/scripts/build_release.py
+++ b/scripts/build_release.py
@@ -161,11 +161,11 @@ def build_win():
     nsis = 'C:\\Program Files (x86)\\NSIS\\makensis.exe'
 
     fname = 'swift_console_{}_windows.exe'.format(version)
-    installer_path = '../dist/{}'.format(fname)
+    installer_path = 'dist/{}'.format(fname)
 
     check_call([
         nsis,
-        '-XOutfile {}'.format(installer_path),
+        '-XOutfile ../{}'.format(installer_path),
         'misc/swift_console.nsi'
     ])
 

--- a/scripts/build_release.py
+++ b/scripts/build_release.py
@@ -125,7 +125,7 @@ def build_linux_bionic():
 
 
 def build_macos():
-    out, version = build('pyinstaller-macos')
+    _out, version = build('pyinstaller-macos')
     fname = 'swift_console_{}_macos.dmg'.format(version)
     check_call([
         'sudo',
@@ -174,7 +174,7 @@ def build_win():
     s3_path = 's3://{}/piksi_tools/{}/windows/{}'.format(S3_BUCKET, version, fname)
 
     print(">>> Uploading to {}".format(s3_path))
-    check_call(['aws', 's3', 'cp', dmg_rel_path, s3_path])
+    check_call(['aws', 's3', 'cp', installer_path, s3_path])
 
 
 def zipdir(path, ziph):

--- a/scripts/build_release.py
+++ b/scripts/build_release.py
@@ -15,10 +15,13 @@ from six.moves import reload_module
 BIONIC_DOCKER_TAG = 'swiftnav/piksi-tools-bionic:2019.06.20'
 S3_BUCKET = 'swiftnav-artifacts'
 
-if (os.environ.get("APPVEYOR_PULL_REQUEST_NUMBER", "") != "" or
-    os.environ.get("TRAVIS_PULL_REQUEST", "false") != "false"):
+appveyor_pr = os.environ.get("APPVEYOR_PULL_REQUEST_NUMBER", "")
+travis_pr = os.environ.get("TRAVIS_PULL_REQUEST", "false")
+
+if (appveyor_pr != "" or travis_pr != "false"):
     S3_BUCKET = 'swiftnav-artifacts-pull-requests'
-    pass
+
+print("S3_BUCKET: {} (APPVEYOR_PULL_REQUEST_NUMBER: {}, TRAVIS_PULL_REQUEST: {})".format(S3_BUCKET, appveyor_pr, travis_pr))
 
 
 def maybe_remove(path):

--- a/scripts/build_release.py
+++ b/scripts/build_release.py
@@ -193,7 +193,7 @@ def build_cli_tools(plat):
     if not plat.startswith('win'):
         with zipfile.ZipFile(fname, 'w') as ziph:
             zipdir(out, ziph)
-        s3_path = 's3://{}/{}/{}/{}'.format(S3_BUCKET, version, plat, fname)
+        s3_path = 's3://{}/piksi_tools/{}/{}/{}'.format(S3_BUCKET, version, plat, fname)
         print(">>> Uploading to {}".format(s3_path))
         check_call(['aws', 's3', 'cp', fname, s3_path])
 
@@ -206,6 +206,7 @@ def main():
     elif plat.startswith('darwin'):
         build_macos()
     elif plat.startswith('win'):
+        plat = "windows"
         build_win()
     build_cli_tools(plat)
 


### PR DESCRIPTION
Seems to work for AppVeyor:
```
>>> Uploading to s3://swiftnav-artifacts/piksi_tools/v2.4.17.dev8+ga851940/windows/swift_console_v2.4.17.dev8+ga851940_windows.exe
```

And Travis:
```
upload: dist/swift_console_v2.4.17.dev10+g3302c9b_linux_legacy.tar.gz to s3://swiftnav-artifacts-pull-requests/piksi_tools/v2.4.17.dev10+g3302c9b/linux_legacy/swift_console_v2.4.17.dev10+g3302c9b_linux_legacy.tar.gz
...
>>> Uploading to s3://swiftnav-artifacts-pull-requests/piksi_tools/v2.4.17.dev10+g3302c9b/linux/swift_console_v2.4.17.dev10+g3302c9b_linux.tar.gz
>>> Uploading to s3://swiftnav-artifacts-pull-requests/piksi_tools/v2.4.17.dev10+g3302c9b/linux/cmdline_tools_v2.4.17.dev10+g3302c9b.zip
...
upload: dist/swift_console_v2.4.17.dev9+g7142a1e_linux_legacy.tar.gz to s3://swiftnav-artifacts/piksi_tools/v2.4.17.dev9+g7142a1e/linux_legacy/swift_console_v2.4.17.dev9+g7142a1e_linux_legacy.tar.gz
...
>>> Uploading to s3://swiftnav-artifacts/piksi_tools/v2.4.17.dev9+g7142a1e/linux/swift_console_v2.4.17.dev9+g7142a1e_linux.tar.gz
>>> Uploading to s3://swiftnav-artifacts/piksi_tools/v2.4.17.dev9+g7142a1e/linux/cmdline_tools_v2.4.17.dev9+g7142a1e.zip
...
>>> Uploading to s3://swiftnav-artifacts/piksi_tools/v2.4.17.dev10+g46799fc/darwin/swift_console_v2.4.17.dev10+g46799fc_macos.dmg
>>> Uploading to s3://swiftnav-artifacts/piksi_tools/v2.4.17.dev10+g46799fc/darwin/cmdline_tools_v2.4.17.dev10+g46799fc.zip
...
upload: dist/swift_console_v2.4.17.dev11+g83625bb_macos.dmg to s3://swiftnav-artifacts-pull-requests/piksi_tools/v2.4.17.dev11+g83625bb/darwin/swift_console_v2.4.17.dev11+g83625bb_macos.dmg
```