### PR TITLE
python-35 build system / CI fixes

### DIFF
--- a/docker/Dockerfile.buster
+++ b/docker/Dockerfile.buster
@@ -39,7 +39,7 @@ RUN \
   && make altinstall \
   && cd /work \
   \
-  && /usr/local/bin/python3.5 -m pip install --upgrade pip \
+  && /usr/local/bin/python3.5 -m pip install --upgrade pip>=19.1.1,<21 \
   && /usr/local/bin/python3.5 -m pip install wheel setuptools tox
 
 ENV PY36=3.6.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pip>=19.1.1
+pip>=19.1.1,<21
 numpy~=1.18.1
 configparser
 future==0.17.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 pip>=19.1.1,<21
+setuptools==41.0.1
+setuptools-scm==3.3.3
 numpy~=1.18.1
 configparser
 future==0.17.1
@@ -13,6 +15,4 @@ six==1.13.0
 libsettings==0.1.12
 sbp~=3.4.4
 ruamel.yaml==0.15.87
-setuptools==41.0.1
-setuptools-scm==3.3.3
 monotonic==1.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,6 @@ pygments==2.2.0
 requests~=2.20.0
 six==1.13.0
 libsettings==0.1.12
-sbp~=3.4.4
+sbp==3.4.5
 ruamel.yaml==0.15.87
 monotonic==1.5

--- a/tasks/setup.sh
+++ b/tasks/setup.sh
@@ -147,7 +147,7 @@ function all_dependencies_debian () {
     validate_linux_mint19
 
     if command -v python3; then
-        run_pip3_install --upgrade pip setuptools
+        run_pip3_install setuptools
         run_pip3_install -r ../requirements.txt
         run_pip3_install -r ../requirements_gui.txt
         run_pip3_install --upgrade awscli

--- a/tasks/setup.sh
+++ b/tasks/setup.sh
@@ -201,7 +201,7 @@ function install_python_deps_osx () {
     conda install --yes \
       virtualenv \
       pytest \
-      swig \
+      swig=3.0.12 \
       six
 
     pip install --upgrade pip


### PR DESCRIPTION
This PR is to address the fact that CI has been broken on the Swift console for a few weeks.
- I pinned pip to the last supported version for python 3.5 (< 21) per the warning from pip command line and this stackoverflow (https://stackoverflow.com/questions/65896334/python-pip-broken-wiith-sys-stderr-writeferror-exc) which was the verbatim error we were getting on travis (https://travis-ci.org/github/swift-nav/piksi_tools/jobs/758592685#L979)
- I removed redundant install of PIP in both the bootstrap setup.sh script and requirements.txt
- pinned SWIG which was crashing pyinstaller version of console on MacOS  with this critical error. It was causing the smoke test to fail there as well. https://travis-ci.org/github/swift-nav/piksi_tools/jobs/758592686#L917
```
Traceback (most recent call last):
  File "enable/qt4/base_window.py", line 213, in paintEvent
  File "enable/qt4/base_window.py", line 65, in paintEvent
  File "enable/abstract_window.py", line 462, in _paint
  File "enable/qt4/image.py", line 23, in _create_gc
  File "kiva/agg/__init__.py", line 40, in __init__
  File "kiva/agg/agg.py", line 859, in __init__
NameError: name '_swig_setattr' is not defined
```
- I updated libsbp (not required,  but good practice)
