### PR TITLE
Dzollo/backport master ci fixes to v3.0.0 create swiftnavdir when updating

### DIFF
--- a/docker/Dockerfile.buster
+++ b/docker/Dockerfile.buster
@@ -39,7 +39,7 @@ RUN \
   && make altinstall \
   && cd /work \
   \
-  && /usr/local/bin/python3.5 -m pip install --upgrade pip \
+  && /usr/local/bin/python3.5 -m pip install --upgrade pip>=19.1.1,<21 \
   && /usr/local/bin/python3.5 -m pip install wheel setuptools tox
 
 ENV PY36=3.6.8

--- a/piksi_tools/console/update_view.py
+++ b/piksi_tools/console/update_view.py
@@ -545,6 +545,9 @@ class UpdateView(HasTraits):
 
         # Get firmware files from Swift Nav's website, save to disk, and load.
         if 'fw' in self.update_dl.index[self.piksi_hw_rev]:
+            if not os.path.exists(self.update_dl.root_dir):
+                os.mkdir(self.update_dl.root_dir)
+                self._write("Creating directory {}".format(self.update_dl.root_dir))
             try:
                 self._write('Downloading Latest Multi firmware')
                 filepath = self.update_dl.download_multi_firmware(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pip>=19.1.1
+pip>=19.1.1,<21
 numpy~=1.18.1
 configparser
 future==0.17.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 pip>=19.1.1,<21
+setuptools==41.0.1
+setuptools-scm==3.3.3
 numpy~=1.18.1
 configparser
 future==0.17.1
@@ -13,6 +15,4 @@ six==1.13.0
 libsettings==0.1.12
 sbp~=3.4.4
 ruamel.yaml==0.15.87
-setuptools==41.0.1
-setuptools-scm==3.3.3
 monotonic==1.5

--- a/tasks/setup.sh
+++ b/tasks/setup.sh
@@ -147,7 +147,7 @@ function all_dependencies_debian () {
     validate_linux_mint19
 
     if command -v python3; then
-        run_pip3_install --upgrade pip setuptools
+        run_pip3_install setuptools
         run_pip3_install -r ../requirements.txt
         run_pip3_install -r ../requirements_gui.txt
         run_pip3_install --upgrade awscli

--- a/tasks/setup.sh
+++ b/tasks/setup.sh
@@ -201,7 +201,7 @@ function install_python_deps_osx () {
     conda install --yes \
       virtualenv \
       pytest \
-      swig \
+      swig=3.0.12 \
       six
 
     pip install --upgrade pip


### PR DESCRIPTION
Here are ONLY the necessary changes from master to fix CI issues and backport a bugfix from master so that Multi firmware can be downloaded even when ~/swiftnav hasn't yet been created.