### PR TITLE
Fix INS Status printing as dec instead of hex

### DIFF
--- a/piksi_tools/console/solution_view.py
+++ b/piksi_tools/console/solution_view.py
@@ -559,7 +559,7 @@ class SolutionView(HasTraits):
                                ('VDOP', EMPTY_STR)]
 
         self.dops_table.append(('DOPS Flags', '0x%03x' % flags))
-        self.dops_table.append(('INS Status', '0x{:0}'.format(self.ins_status_flags)))
+        self.dops_table.append(('INS Status', '0x{:08x}'.format(self.ins_status_flags)))
 
     def ins_status_callback(self, sbp_msg, **metadata):
         status = MsgInsStatus(sbp_msg)


### PR DESCRIPTION
Looks like the INS status is currently printed in decimal instead of hex, which is a little confusing with the leading `0x` :)

Tested this by running the CI built console (`s3://swiftnav-artifacts/piksi_tools/v3.0.1.dev15+g45dda95/linux/swift_console_v3.0.1.dev15+g45dda95_linux.tar.gz`) and confirming the console showed the message in hex as expected.