### PR TITLE
Update pygments dependency, CVE-2021-20270

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ pep8==1.7.0
 pyserial==3.4
 pylibftdi==0.16.1.2
 pyparsing==2.2.0
+pygments==2.7.4
 requests~=2.20.0
 six==1.13.0
 libsettings==0.1.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ pep8==1.7.0
 pyserial==3.4
 pylibftdi==0.16.1.2
 pyparsing==2.2.0
-pygments==2.2.0
 requests~=2.20.0
 six==1.13.0
 libsettings==0.1.12


### PR DESCRIPTION
~Since we don't import pygments directly anymore, we shouldn't need it in our `requirements.txt`~ pyface imports it at runtime I guess, will try updating the version instead -- addresses CVE-2021-20270.