### PR TITLE
Add new settings for fusion engine for Piksi 2.5

### DIFF
--- a/piksi_tools/console/settings.yaml
+++ b/piksi_tools/console/settings.yaml
@@ -2565,6 +2565,30 @@
   readonly: true
   Description: inertial navigation system build date
 
+- group: ins
+  name: antenna_offset_deviation
+  type: double
+  units: meters
+  default value: 0.05
+  readonly: False
+  Description: Standard deviation of antenna lever arm measurement.
+  Notes: |
+    Must be greater than 0.
+
+    This value should overestimate the actual expected error.
+
+- group: ins
+  name: vehicle_frame_deviation
+  type: double
+  units: degrees
+  default value: 1
+  readonly: False
+  Description: Standard deviation of misalignment measurement.
+  Notes: |
+    Must be greater than 0.
+
+    This value should overestimate the actual expected error.
+
 - group: metrics_daemon
   name: metrics_update_interval
   expert: true


### PR DESCRIPTION
Adds the antenna_offset_deviation and vehicle_frame_deviation settings
that are used in Piksi 2.5 to configure the fusion engine. Descriptions
and notes have been taken from the Starling user manual.