### PR TITLE
Add ANT status, fix DR string, missing settings, remove ini default file. [DEVINFRA-529][DEVINFRA-530][DEVINFRA-531]

### DIFF
--- a/piksi_tools/console/console.py
+++ b/piksi_tools/console/console.py
@@ -190,6 +190,7 @@ class SwiftConsole(HasTraits):
   """
     pos_mode = Str('')
     rtk_mode = Str('')
+    ant_status_string = Str('')
     ins_status_string = Str('')
     num_sats_str = Str('')
     cnx_desc = Str('')
@@ -377,6 +378,16 @@ class SwiftConsole(HasTraits):
                         padding=2,
                         show_label=False,
                         style='readonly', width=6),
+                    Item(
+                        '',
+                        label='Ant:',
+                        emphasized=True,
+                        tooltip='Ant Status String'
+                    ), Item(
+                        'ant_status_string',
+                        padding=2,
+                        show_label=False,
+                        style='readonly', width=6),
                     Spring(springy=True),
                     Item('driver_data_rate',
                          style='readonly',
@@ -465,12 +476,14 @@ class SwiftConsole(HasTraits):
             self.observation_view_base.dirname = self.directory_name
 
     def update_on_heartbeat(self, sbp_msg, **metadata):
+        self.last_heartbeat_msg_flags = sbp_msg.flags
         self.heartbeat_count += 1
 
     def check_heartbeat(self):
         # if our heartbeat hasn't changed since the last timer interval the connection must have dropped
         if self.heartbeat_count == self.last_timer_heartbeat and self.heartbeat_count != 0:
             self.solid_connection = False
+            self.ant_status_string = "None"
             self.ins_status_string = "None"
             self.pos_mode = "None"
             self.ins_mode = "None"
@@ -498,7 +511,19 @@ class SwiftConsole(HasTraits):
 
         baseline_display_mode = "None"
 
+        ant_status_string = EMPTY_STR
         ins_status_string = EMPTY_STR
+
+        # determine the antenna status
+        if self.last_heartbeat_msg_flags is not None:
+            if self.last_heartbeat_msg_flags & 0x40000000:
+                ant_status_string = "Short"
+            elif self.last_heartbeat_msg_flags & 0x80000000:
+                ant_status_string = "Ok"
+            else:
+                ant_status_string = "Open"
+        self.ant_status_string = ant_status_string
+
 
         # determine the latest llh solution mode
         if self.solution_view and (current_time -
@@ -537,8 +562,8 @@ class SwiftConsole(HasTraits):
             if ins_error != 0:
                 ins_status_string = ins_error_dict.get(ins_error, "Unk Error")
             else:
-                ins_status_string = ins_type_dict.get(ins_type, "unk") + "-"
-                ins_status_string += ins_mode_dict.get(ins_mode, "unk")
+                ins_status_string = ins_type_dict.get(ins_type, "Unk-")
+                ins_status_string += ins_mode_dict.get(ins_mode, "Unk")
                 if odo_status == 1:
                     ins_status_string += "+Odo"
 
@@ -651,12 +676,14 @@ class SwiftConsole(HasTraits):
         self.dev_id = cnx_desc
         self.num_sats_str = EMPTY_STR
         self.mode = ''
+        self.ant_status_string = "None"
         self.ins_status_string = "None"
         self.forwarder = None
         self.age_of_corrections = '--'
         self.expand_json = expand_json
         # if we have passed a logfile, we set our directory to it
         override_filename = override_filename
+        self.last_heartbeat_msg_flags = None
         self.last_status_update_time = 0
         self.last_driver_bytes_read = 0
         self.driver = driver

--- a/piksi_tools/console/settings.yaml
+++ b/piksi_tools/console/settings.yaml
@@ -1547,6 +1547,18 @@
   Description: Minimum speed for outputting Course-Over-Ground values.
   Notes: For value '0' Course-Over-Ground is output always when fix is available.
 
+- group: nmea
+  name: cog_update_min_speed
+  expert: true
+  type: float
+  digits: '1'
+  units: Meters per second
+  default value: '0.1'
+  readonly: false
+  enumerated possible values:
+  Description: Minimum speed for updating the current Course-Over-Ground value.
+  Notes: For value '0' Course-Over-Ground is updated always when a fix is available. For non '0' values, the Course-Over-Ground value will only be recomputed and updated when the speed exceeds the specified value.
+
 - group: ntrip
   name: enable
   expert: false
@@ -1807,6 +1819,53 @@
   default value: 'False'
   readonly: false
   Description: Additional debug messages for cell modem. This setting must be saved and the device rebooted for it to take effect.
+
+- group: tls_client0
+  name: mode
+  expert: false
+  type: enum
+  units: N/A
+  default value: 'Disabled'
+  readonly: false
+  enumerated possible values: SBP,NMEA OUT,RTCMv3 IN,RTCMv3 OUT
+  Description: Communication protocol for TLS client 0. The client will initiate a connection with the server and establish bi-directional communications.
+  Notes: |
+    "SBP" configures the interface to transmit messages specified in the 'enabled_sbp_messages' setting and to receive incoming SBP messages. If the mode is changed from SBP the console will no longer be able to communicate over the interface.
+
+    "NMEA OUT" configures the interface to transmit the GGA, RMC, GGL, VTG, ZDA, GSA, and GSV NMEA 0183 messages. The interface will not receive incoming messages.
+
+    "RTCMv3 IN" configures the interface to receive RTK corrections in RTCMv3 format. The interface will receive 1002, 1004, 1005, 1006, 1010, 1012, 1033, 1230 and MSM4-7 RTCMv3 messages and will not transmit or receive any other messages.
+
+    "RTCMv3 OUT" configures the interface to transmit RTCMv3 messages.
+
+    The connection is bi-directional so these modes behave the same as the UART modes.
+
+- group: tls_client0
+  name: enabled_sbp_messages
+  expert: false
+  type: string
+  units: N/A
+  default value: '23,65,72,74,81,97,117,134,136,137,138,139, 144,149,163,165,166,167,171,175,181, 185,187,188,189,190,257,258,259,520,522, 524,526,527,528,1025,2304/50,2305,2306/50, 30583,65280,65282,65535'
+  readonly: false
+  Description: Configure which messages should be sent on the port. Does not effect which incoming messages are listened to.
+  Notes: The enabled sbp messages settings is a list of message types
+    and rate divisors that will be sent out of the interface. If left blank, all
+    messages will be sent. If not blank, a comma separated list of
+    SBP message IDs in base 10 integer format should be provided. Optionally,
+    a divisor can be specified after the / character for each id. For example, an entry of
+    3456/10 would provide message with ID 3456 at 1/10th the normal rate. For Ethernet,
+    the default value is optimal for logging and communication with the console.
+
+- group: tls_client0
+  name: address
+  expert: false
+  type: string
+  units: N/A
+  default value: ''
+  readonly: false
+  Description: IP address and port for TLS client 0 to connect to.
+  Notes: The address setting is defined according to the convention "hostname:port".
+    For example, it should match the format 192.168.0.222:55555 or xxxxx.net:2101 .
 
 - group: tcp_server0
   name: mode
@@ -2192,6 +2251,14 @@
   readonly: false
   Description: Override the device used for cell modem connectivity. If left empty, uses default device discovery to determine the correct device to use.
   Notes: Cell modem 'enable' must be 'False' in order to change this setting.
+
+- group: standalone_logging
+  name: blacklist_sdcard
+  expert: true
+  type: boolean
+  default value: 'False'
+  readonly: false
+  Description: Enable/Disable SD Card.
 
 - group: standalone_logging
   name: file_duration

--- a/piksi_tools/console/settings_view.py
+++ b/piksi_tools/console/settings_view.py
@@ -644,7 +644,7 @@ class SettingsView(HasTraits):
         # Prompt user for location and name of file
         file = FileDialog(action='save as',
                           default_directory=swift_path,
-                          default_filename='config.ini',
+                          default_filename='',
                           wildcard='*.ini')
 
         if file.open() != OK:
@@ -749,7 +749,7 @@ class SettingsView(HasTraits):
         # Prompt user for file
         file = FileDialog(action='open',
                           default_directory=swift_path,
-                          default_filename='config.ini',
+                          default_filename='*.ini',
                           wildcard='*.ini')
         if file.open() != OK:
             # No error message here because user likely pressed cancel when choosing file

--- a/piksi_tools/console/update_view.py
+++ b/piksi_tools/console/update_view.py
@@ -442,6 +442,8 @@ class UpdateView(HasTraits):
         text : string
           Text to be written to screen.
         """
+        if self.stream is None:
+            return
         self.stream.write(text)
         self.stream.write('\n')
         self.stream.flush()
@@ -632,9 +634,6 @@ class UpdateView(HasTraits):
 
         # Check that we received the index file from the website.
         if self.update_dl is None:
-            self._write(
-                "\nWarning: Unable to fetch firmware release index from Swift to determine update status.\n"
-            )
             return
         # Get local stm version
         local_stm_version = None

--- a/piksi_tools/console/utils.py
+++ b/piksi_tools/console/utils.py
@@ -492,8 +492,8 @@ SMOOTHPOSE = 0
 DR_RUNNER = 1
 
 ins_type_dict = {
-    SMOOTHPOSE: "SP",
-    DR_RUNNER: "INS"
+    SMOOTHPOSE: "SP-",
+    DR_RUNNER: ""
 }
 
 color_dict = {


### PR DESCRIPTION
* Adds the Ant status to the status bar.
* Fix DR string per recommendation by Stefan.
* Added missing settings [blacklist_sdcard, cog_update_min_speed, tls_client0.address, tls_client0.enabled_sbp_messages, tls_client0.mode] (This might need more detailed descriptions at a later time)
* Removed the default ini file suggested when importing settings file.
* Fixed crash when connecting to a serial device with no internet connection (Output stream in update would throw a traceback so routed this to None).
* Removed warning which pops up in update tab if no internet connection and trying to connect via serial. Now nothing is displayed.