### PR TITLE
Fix travis break.

### DIFF
--- a/piksi_tools/console/console.py
+++ b/piksi_tools/console/console.py
@@ -524,7 +524,6 @@ class SwiftConsole(HasTraits):
                 ant_status_string = "Open"
         self.ant_status_string = ant_status_string
 
-
         # determine the latest llh solution mode
         if self.solution_view and (current_time -
                                    self.solution_view.last_stime_update) < UPDATE_TOLERANCE_SECONDS:

--- a/piksi_tools/console/sbp_relay_view.py
+++ b/piksi_tools/console/sbp_relay_view.py
@@ -15,8 +15,7 @@ from sbp.client.loggers.udp_logger import UdpLogger
 from sbp.observation import (SBP_MSG_BASE_POS_ECEF, SBP_MSG_BASE_POS_LLH,
                              SBP_MSG_OBS, SBP_MSG_OBS_DEP_B, SBP_MSG_OBS_DEP_C)
 from sbp.piksi import (SBP_MSG_NETWORK_STATE_RESP, MsgNetworkStateReq)
-from traits.api import Bool, Button, Enum, HasTraits, Int, String, List, \
-    Instance
+from traits.api import Bool, Button, Enum, HasTraits, Int, String, List
 from traitsui.api import (HGroup, Item, TextEditor, UItem, VGroup,
                           View, spring, TabularEditor)
 
@@ -75,59 +74,61 @@ class SbpRelayView(HasTraits):
         height=16,
         aligment='center')
     view = View(
-        VGroup(spring,
-               HGroup(
-                   VGroup(
-                       Item(
-                           'msg_enum',
-                           label="Messages to broadcast",
-                           style='custom',
-                           enabled_when='not running'),
-                       Item(
-                           'ip_ad',
-                           label='IP Address',
-                           enabled_when='not running'),
-                       Item('port', label="Port", enabled_when='not running'),
-                       HGroup(spring,
-                              UItem(
-                                  'start',
-                                  enabled_when='not running',
-                                  show_label=False),
-                              UItem(
-                                  'stop',
-                                  enabled_when='running',
-                                  show_label=False), spring)),
-                   VGroup(
-                       Item(
-                           'information',
-                           label="Notes",
-                           height=10,
-                           editor=MultilineTextEditor(
-                               TextEditor(multi_line=True)),
-                           style='readonly',
-                           show_label=False,
-                           resizable=True,
-                           padding=15),
-                       spring,
-                   )
-               ),
-               spring,
-               HGroup(
-                   VGroup(
-                          Item(
-                              '_network_info',
-                              style='readonly',
-                              editor=TabularEditor(
-                                  adapter=SimpleNetworkAdapter()),
-                              show_label=False, ),
-                          Item(
-                              'network_refresh_button', show_label=False,
-                              width=0.50),
-                          show_border=True,
-                          label="Network",
-                    ),
+        VGroup(
+            spring,
+            HGroup(
+                VGroup(
+                    Item(
+                        'msg_enum',
+                        label="Messages to broadcast",
+                        style='custom',
+                        enabled_when='not running'),
+                    Item(
+                        'ip_ad',
+                        label='IP Address',
+                        enabled_when='not running'),
+                    Item('port', label="Port", enabled_when='not running'),
+                    HGroup(
+                        spring,
+                        UItem(
+                            'start',
+                            enabled_when='not running',
+                            show_label=False),
+                        UItem(
+                            'stop',
+                            enabled_when='running',
+                            show_label=False), spring)),
+                VGroup(
+                    Item(
+                        'information',
+                        label="Notes",
+                        height=10,
+                        editor=MultilineTextEditor(
+                            TextEditor(multi_line=True)),
+                        style='readonly',
+                        show_label=False,
+                        resizable=True,
+                        padding=15),
+                    spring,
                 )
+            ),
+            spring,
+            HGroup(
+                VGroup(
+                    Item(
+                        '_network_info',
+                        style='readonly',
+                        editor=TabularEditor(
+                            adapter=SimpleNetworkAdapter()),
+                        show_label=False, ),
+                    Item(
+                        'network_refresh_button', show_label=False,
+                        width=0.50),
+                    show_border=True,
+                    label="Network",
+                ),
             )
+        )
     )
 
     def _network_callback(self, m, **metadata):

--- a/piksi_tools/console/solution_view.py
+++ b/piksi_tools/console/solution_view.py
@@ -304,11 +304,11 @@ class SolutionView(HasTraits):
 
     def update_table(self):
         self.table = (
-            self.pos_table
-            + self.vel_table
-            + self.dops_table
-            + self.angular_rate_table
-            + self.orient_euler_table
+            self.pos_table +
+            self.vel_table +
+            self.dops_table +
+            self.angular_rate_table +
+            self.orient_euler_table
         )
 
     def auto_survey(self):

--- a/piksi_tools/console/utils.py
+++ b/piksi_tools/console/utils.py
@@ -639,8 +639,10 @@ def get_mode(msg):
 def datetime_2_str(datetm):
     return (datetm.strftime('%Y-%m-%d %H:%M'), datetm.strftime('%S.%f'))
 
+
 def microdegrees_2_degrees(deg):
     return round(deg / 1000000, 2)
+
 
 # Modified based on https://stackoverflow.com/a/1094933
 def sizeof_fmt(num, suffix='B'):

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,6 @@ pygments==2.7.4
 requests~=2.20.0
 six==1.13.0
 libsettings==0.1.12
-sbp~=3.4.4
+sbp==3.4.5
 ruamel.yaml==0.15.87
 monotonic==1.5

--- a/tasks/setup.sh
+++ b/tasks/setup.sh
@@ -118,7 +118,7 @@ function all_dependencies_debian () {
     run_apt_install \
          git \
          build-essential \
-         python-setuptools \
+         python-setuptools=50.0 \
          python-virtualenv \
          swig \
          libicu-dev \

--- a/tasks/setup.sh
+++ b/tasks/setup.sh
@@ -147,7 +147,7 @@ function all_dependencies_debian () {
     validate_linux_mint19
 
     if command -v python3; then
-        run_pip3_install setuptools
+        run_pip3_install setuptools==41.0.1
         run_pip3_install -r ../requirements.txt
         run_pip3_install -r ../requirements_gui.txt
         run_pip3_install --upgrade awscli

--- a/tasks/setup.sh
+++ b/tasks/setup.sh
@@ -118,7 +118,7 @@ function all_dependencies_debian () {
     run_apt_install \
          git \
          build-essential \
-         python-setuptools=50.0 \
+         python-setuptools \
          python-virtualenv \
          swig \
          libicu-dev \


### PR DESCRIPTION
* Fixes travis CI by fixing setuptools in some files to an older version. It seems there is a break beyond 50.0.0.
* Sets libsbp to 3.4.5 instead of 3.4.4. It appears there was a new addition to 3.4.4 which was causing a syntax error for the construct package in sbp. Not entirely sure why bumping to 3.4.5 resolved this.

I tested the Linux build and it looks okay. 
The mac build has some odd highlighting on the main / subtabs not sure if that is normal though?

<img width="797" alt="Screen Shot 2021-08-09 at 10 54 57 AM" src="https://user-images.githubusercontent.com/43353147/128751748-567921b1-1d3a-4a6c-9490-81e8b353f6a1.png">
<img width="801" alt="Screen Shot 2021-08-09 at 10 58 30 AM" src="https://user-images.githubusercontent.com/43353147/128751992-18338829-752c-4ba7-b4c9-2c309d84118f.png">
