### PR TITLE
workaround for macOS 11 white-on-white tabs [DEVINFRA-567]

### DIFF
--- a/piksi_tools/console/console.py
+++ b/piksi_tools/console/console.py
@@ -130,12 +130,19 @@ def get_args():
     return parser
 
 
-def is_macos11():
-    cp = subprocess.run(['/usr/bin/python3', '-c', 'import platform; import json; print(json.dumps(platform.mac_ver()))'],
-                        check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.DEVNULL)
-    if cp.returncode == 0:
+def _is_macos11():
+    usr_bin_python3 = '/usr/bin/python3'
+    if not os.path.exists(usr_bin_python3):
+        return False
+    child = subprocess.run([usr_bin_python3, '-c',
+                            'import platform; import json; print(json.dumps(platform.mac_ver()))'],
+                           check=False,
+                           stdout=subprocess.PIPE,
+                           stderr=subprocess.PIPE,
+                           stdin=subprocess.DEVNULL)
+    if child.returncode == 0:
         try:
-            mac_ver = json.loads(cp.stdout)
+            mac_ver = json.loads(child.stdout)
         except json.decoder.JSONDecodeError:
             return False
         if len(mac_ver) > 0:
@@ -289,11 +296,11 @@ class SwiftConsole(HasTraits):
          padding-left: 6px;
          padding-right: 6px;
       }
-    ''' % { 'color': macos11_blue }
+    ''' % {'color': macos11_blue}
 
     qt_style_sheet = ''
 
-    if is_macos11():
+    if _is_macos11():
         qt_style_sheet = macos11_qt_style_sheet
 
     view = View(

--- a/piksi_tools/console/console.py
+++ b/piksi_tools/console/console.py
@@ -14,9 +14,11 @@ from __future__ import print_function
 
 import argparse
 # Logging
+import json
 import logging
 import os
 import signal
+import subprocess
 import sys
 import time
 from monotonic import monotonic
@@ -126,6 +128,25 @@ def get_args():
         version='Swift Console {}'.format(CONSOLE_VERSION)
     )
     return parser
+
+
+def is_macos11():
+    cp = subprocess.run(['/usr/bin/python3', '-c', 'import platform; import json; print(json.dumps(platform.mac_ver()))'],
+                        check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.DEVNULL)
+    if cp.returncode == 0:
+        try:
+            mac_ver = json.loads(cp.stdout)
+        except json.decoder.JSONDecodeError:
+            return False
+        if len(mac_ver) > 0:
+            mac_ver = mac_ver[0]
+            try:
+                mac_ver = float(mac_ver)
+                return mac_ver >= 11.0
+            except ValueError:
+                return False
+        return False
+    return False
 
 
 CONSOLE_TITLE = 'Swift Console ' + CONSOLE_VERSION
@@ -255,6 +276,26 @@ class SwiftConsole(HasTraits):
         width=8,
         height=8)
 
+    macos11_blue = '#277cf6'
+
+    macos11_qt_style_sheet = '''
+      QTabBar::tab:selected {
+         background-color: %(color)s;
+         color: white;
+         border-top-left-radius: 4px;
+         border-bottom-left-radius: 4px;
+         border-top-right-radius: 4px;
+         border-bottom-right-radius: 4px;
+         padding-left: 6px;
+         padding-right: 6px;
+      }
+    ''' % { 'color': macos11_blue }
+
+    qt_style_sheet = ''
+
+    if is_macos11():
+        qt_style_sheet = macos11_qt_style_sheet
+
     view = View(
         VSplit(
             Tabbed(
@@ -291,7 +332,8 @@ class SwiftConsole(HasTraits):
                         style='custom'),
                     label='Advanced',
                     show_labels=False),
-                show_labels=False),
+                show_labels=False,
+                style_sheet=qt_style_sheet),
             VGroup(
                 VGroup(
                     HGroup(

--- a/tasks/setup.sh
+++ b/tasks/setup.sh
@@ -199,7 +199,7 @@ function install_python_deps_osx () {
     pip install -r "$ROOT/requirements_gui.txt"
     pip install -e "$ROOT"
 
-    pip install PySide2==5.15.2
+    pip install pyqt5==5.10.0
 
     log_info ""
     log_info "To run piksi_tools from source, do the following:"

--- a/tox.ini
+++ b/tox.ini
@@ -91,8 +91,8 @@ basepython = python3.6
 usedevelop = True
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/requirements_dev.txt
-       PySide2==5.15.2
-       pyinstaller==4.3
+       pyqt5==5.10.0
+       pyinstaller==3.6
 
 commands =
         pip install -r requirements_gui.txt


### PR DESCRIPTION
Forces tab to be styled with macOS 11 blue accent color, which is what Qt defaults to on macOS 11.  Qt ignores changes in the accent color so this workaround doesn't attempt to match the accent color that's currently selected in the system preferences.

Appearance on macOS 11 (Big Sur)

<img width="804" alt="Screen Shot 2021-10-12 at 9 49 56 PM" src="https://user-images.githubusercontent.com/183436/137070460-4292657c-fb41-47d3-a344-1efd089f53da.png">

On macOS 10.15 (Catalina):

![catalina_console](https://user-images.githubusercontent.com/183436/137071523-ff7f0011-8284-44ed-a595-9be59b9c3e43.png)

Linux and Windows look the same as before:

![linux_console](https://user-images.githubusercontent.com/183436/137071544-3d737bc7-d0de-494e-b5f8-f93abd06c31c.png)

![Screenshot 2021-10-12 221455](https://user-images.githubusercontent.com/183436/137071556-ef669834-3dfc-4b99-be4b-4464e769e924.png)
