### PR TITLE
Merge cherry-picks from refs/heads/v3.1.0-release (6c9be5520) into master: workaround for macOS 11 white-on-white tabs [DEVINFRA-567] (#1265)

### DIFF
--- a/tasks/setup.sh
+++ b/tasks/setup.sh
@@ -199,7 +199,7 @@ function install_python_deps_osx () {
     pip install -r "$ROOT/requirements_gui.txt"
     pip install -e "$ROOT"
 
-    pip install PySide2==5.15.2
+    pip install pyqt5==5.10.0
 
     log_info ""
     log_info "To run piksi_tools from source, do the following:"

--- a/tox.ini
+++ b/tox.ini
@@ -91,8 +91,8 @@ basepython = python3.6
 usedevelop = True
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/requirements_dev.txt
-       PySide2==5.15.2
-       pyinstaller==4.3
+       pyqt5==5.10.0
+       pyinstaller==3.6
 
 commands =
         pip install -r requirements_gui.txt


### PR DESCRIPTION
Merges cherry-picked changes from release branch refs/heads/v3.1.0-release into the integration branch master