### PR TITLE
Unpacking Error

### DIFF
--- a/piksi_tools/settings.py
+++ b/piksi_tools/settings.py
@@ -247,12 +247,12 @@ class Settings(object):
         print(msg.text.decode('ascii'))
 
     def _settings_callback(self, sbp_msg, **metadata):
-        section, setting, value, format_type = sbp_msg.payload.split(b'\0')[:4]
+        section, setting, value, *rest = sbp_msg.payload.split(b'\0')[:4]
         self.read_response_wait_dict[(
             section.decode(KEY_ENCODING), setting.decode(KEY_ENCODING))] = value.decode(VALUE_ENCODING)
 
     def _settings_list_callback(self, sbp_msg, **metadata):
-        section_b, setting_b, value_b, format_type_b = sbp_msg.payload[2:].split(b'\0')[:4]
+        section_b, setting_b, value_b, *rest = sbp_msg.payload[2:].split(b'\0')[:4]
         section = section_b.decode(KEY_ENCODING)
         setting = setting_b.decode(KEY_ENCODING)
         value = value_b.decode(VALUE_ENCODING)

--- a/piksi_tools/settings.py
+++ b/piksi_tools/settings.py
@@ -247,12 +247,15 @@ class Settings(object):
         print(msg.text.decode('ascii'))
 
     def _settings_callback(self, sbp_msg, **metadata):
-        section, setting, value, *rest = sbp_msg.payload.split(b'\0')[:4]
+        section, setting, value, *format_type = sbp_msg.payload.split(b'\0')[:4]
+        section = section.decode(KEY_ENCODING)
+        setting = setting.decode(KEY_ENCODING)
+        value = value.decode(VALUE_ENCODING) if format_type else None
         self.read_response_wait_dict[(
-            section.decode(KEY_ENCODING), setting.decode(KEY_ENCODING))] = value.decode(VALUE_ENCODING)
+            section, setting)] = value
 
     def _settings_list_callback(self, sbp_msg, **metadata):
-        section_b, setting_b, value_b, *rest = sbp_msg.payload[2:].split(b'\0')[:4]
+        section_b, setting_b, value_b, *format_type_b = sbp_msg.payload[2:].split(b'\0')[:4]
         section = section_b.decode(KEY_ENCODING)
         setting = setting_b.decode(KEY_ENCODING)
         value = value_b.decode(VALUE_ENCODING)


### PR DESCRIPTION
I stumbled upon this issue while refactoring some code that depends on it.
Example response payload:
```python
b'ins\x00output_mode\x00'
```
### Error:
```bash
Attempting to read:section=ins|setting=output_mode
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/sbp/client/handler.py", line 208, in _call
    callback(msg, **metadata)
  File "/usr/local/lib/python3.8/dist-packages/piksi_tools/settings.py", line 319, in _settings_callback
    section, setting, value, format_type = sbp_msg.payload.split(b'\0')[:4]
ValueError: not enough values to unpack (expected 4, got 3)
```

### Update:
After some digging it seems like this is intended behavior when a [setting is not found](https://github.com/swift-nav/piksi_apps/blob/8390aab4df47dd88ebd2dc17ee831dcbdc5b9a33/app/sbp_settings_daemon/settings_sbp_cb.c#L175).

>       /* Send only section and name fields to indicate that setting was not found.
>       * Note that this is different from sending `section\0name\0\0` which stands
>       * for empty string for value field.
>       */ 

Based on our spec, a settings read response should always look like `SECTION SETTING\0SETTING\0VALUE\0` but if the value is not found, the response will be `SECTION SETTING\0SETTING\0`.
